### PR TITLE
🐛(Identity) Check proper permission for remove claim

### DIFF
--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -96,7 +96,7 @@ contract Identity is ERC734, IIdentity {
     */
     function removeClaim(bytes32 _claimId) public override returns (bool success) {
         if (msg.sender != address(this)) {
-            require(keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Permissions: Sender does not have CLAIM key");
+            require(keyHasPurpose(keccak256(abi.encode(msg.sender)), 3), "Permissions: Sender does not have CLAIM key");
         }
 
         if (claims[_claimId].topic == 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Ethereum solidity smart contracts for Blockchain OnchainID identities.",
   "files": [
     "build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Ethereum solidity smart contracts for Blockchain OnchainID identities.",
   "files": [
     "build",


### PR DESCRIPTION
`removeClaim` was expecting the caller to have a MANAGEMENT key instead of a CLAIM key.