### PR TITLE
releases/1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2021-01-21
+### Added
+- Ownable 0.8.0
+- Context 0.8.0
+### Updated
+- Update version to 1.3.0
+- Update contracts to SOL =0.8.0
+- Update test to work with truffle
+- Update truffle-config.js
+
 ## [1.2.0] - 2020-11-27
 ### Added
 - Custom Upgradable Proxy contract that behaves similarly to the [EIP-1822](https://eips.ethereum.org/EIPS/eip-1822): Universal Upgradeable Proxy Standard (UUPS), except that it points to an Authority contract which in itself points to an implementation (which can be updated).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update contracts to SOL =0.8.0
 - Update test to work with truffle
 - Update truffle-config.js
+- Update solhint config
 
 ## [1.2.0] - 2020-11-27
 ### Added

--- a/contracts/version/Version.sol
+++ b/contracts/version/Version.sol
@@ -10,7 +10,7 @@ contract Version {
      * @dev Returns the string of the current version.
      */
     function version() public pure returns (string memory) {
-        // version 1.0.0
-        return "1.0.0";
+        // version 1.3.0
+        return "1.3.0";
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Ethereum solidity smart contracts for Blockchain OnchainID identities.",
   "files": [
     "build",

--- a/test/IdentityProxy.test.js
+++ b/test/IdentityProxy.test.js
@@ -51,7 +51,7 @@ contract('Identity', function ([
     });
 
     it('Should return version', async function () {
-      expect(await this.identity.version()).to.equals("1.0.0");
+      expect(await this.identity.version()).to.equals("1.3.0");
     });
 
     context('when updating the implementation', function() {


### PR DESCRIPTION
## [1.3.0] - 2021-01-21
[X] Ownable 0.8.0
[X] Context 0.8.0
[X] Update version to 1.3.0
[X] Update contracts to SOL =0.8.0
[X] Update test to work with truffle
[X] Update truffle-config.js
[X] Update solhint config