### PR TITLE
🐛(audit) Correction on execute and approval methods

### DIFF
--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -144,8 +144,8 @@ contract Identity is Storage, IIdentity, Version {
             }
         } else {
             _executions[_id].approved = false;
+            return false;
         }
-        return true;
     }
 
     /**

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -92,10 +92,8 @@ contract Identity is Storage, IIdentity, Version {
 
     /**
      *  @notice Approves an execution or claim addition.
-     *  This SHOULD require an approval of key purpose 1, if the _to of the execution is the identity contract
-     *  itself, to successfully approve an execution.
-     *  And COULD require an approval of key purpose 2, if the _to of the execution is another contract, to
-     *  successfully approve an execution.
+     * If the sender is an ACTION key and the destination address is not the identity contract itself, then the approval is authorized and the operation would be performed.
+     * If the destination address is the identity itself, then the execution would be authorized and performed only if the sender is a MANAGEMENT key.
      */
     function approve(uint256 _id, bool _approve)
     public
@@ -119,7 +117,7 @@ contract Identity is Storage, IIdentity, Version {
             _executions[_id].approved = true;
 
             // solhint-disable-next-line avoid-low-level-calls
-            (success,) = _executions[_id].to.call{value:(_executions[_id].value)}(abi.encode(_executions[_id].data, 0));
+            (success,) = _executions[_id].to.call{value:(_executions[_id].value)}(_executions[_id].data);
 
             if (success) {
                 _executions[_id].executed = true;
@@ -140,7 +138,7 @@ contract Identity is Storage, IIdentity, Version {
                     _executions[_id].data
                 );
 
-                return false;
+                revert("Execution failed.");
             }
         } else {
             _executions[_id].approved = false;
@@ -150,10 +148,11 @@ contract Identity is Storage, IIdentity, Version {
 
     /**
      * @notice Passes an execution instruction to the keymanager.
-     * SHOULD require approve to be called with one or more keys of purpose 1 or 2 to approve this execution.
-     * Execute COULD be used as the only accessor for addKey, removeKey and replaceKey and removeClaim.
+     * If the sender is an ACTION key and the destination address is not the identity contract itself, then the execution is immediately approved and performed.
+     * If the destination address is the identity itself, then the execution would be performed immediately only if the sender is a MANAGEMENT key.
+     * Otherwise, the execute method triggers an ExecutionRequested event, and the execution request must be approved using the `approve` method.
      *
-     * @return executionId SHOULD be sent to the approve function, to approve or reject this execution.
+     * @return executionId to use in the approve function, to approve or reject this execution.
      */
     function execute(address _to, uint256 _value, bytes memory _data)
     public
@@ -162,23 +161,23 @@ contract Identity is Storage, IIdentity, Version {
     payable
     returns (uint256 executionId)
     {
-        require(!_executions[_executionNonce].executed, "Already executed");
-        uint256 executionId = _executionNonce;
-        _executions[_executionNonce].to = _to;
-        _executions[_executionNonce].value = _value;
-        _executions[_executionNonce].data = _data;
+        uint256 _executionId = _executionNonce;
+        require(!_executions[_executionId].executed, "Already executed");
+        _executions[_executionId].to = _to;
+        _executions[_executionId].value = _value;
+        _executions[_executionId].data = _data;
         _executionNonce++;
 
-        emit ExecutionRequested(_executionNonce, _to, _value, _data);
+        emit ExecutionRequested(_executionId, _to, _value, _data);
 
         if (keyHasPurpose(keccak256(abi.encode(msg.sender)), 1)) {
-            approve(executionId, true);
+            approve(_executionId, true);
         }
         else if (_to != address(this) && keyHasPurpose(keccak256(abi.encode(msg.sender)), 2)){
-            approve(executionId, true);
+            approve(_executionId, true);
         }
 
-        return executionId;
+        return _executionId;
     }
 
     /**

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -92,8 +92,10 @@ contract Identity is Storage, IIdentity, Version {
 
     /**
      *  @notice Approves an execution or claim addition.
-     * If the sender is an ACTION key and the destination address is not the identity contract itself, then the approval is authorized and the operation would be performed.
-     * If the destination address is the identity itself, then the execution would be authorized and performed only if the sender is a MANAGEMENT key.
+     * If the sender is an ACTION key and the destination address is not the identity contract itself, then the
+     * approval is authorized and the operation would be performed.
+     * If the destination address is the identity itself, then the execution would be authorized and performed only
+     * if the sender is a MANAGEMENT key.
      */
     function approve(uint256 _id, bool _approve)
     public
@@ -147,9 +149,12 @@ contract Identity is Storage, IIdentity, Version {
 
     /**
      * @notice Passes an execution instruction to the keymanager.
-     * If the sender is an ACTION key and the destination address is not the identity contract itself, then the execution is immediately approved and performed.
-     * If the destination address is the identity itself, then the execution would be performed immediately only if the sender is a MANAGEMENT key.
-     * Otherwise, the execute method triggers an ExecutionRequested event, and the execution request must be approved using the `approve` method.
+     * If the sender is an ACTION key and the destination address is not the identity contract itself, then the
+     * execution is immediately approved and performed.
+     * If the destination address is the identity itself, then the execution would be performed immediately only if
+     * the sender is a MANAGEMENT key.
+     * Otherwise, the execute method triggers an ExecutionRequested event, and the execution request must be approved
+     * using the `approve` method.
      *
      * @return executionId to use in the approve function, to approve or reject this execution.
      */

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -115,13 +115,12 @@ contract Identity is Storage, IIdentity, Version {
 
         if (_approve == true) {
             _executions[_id].approved = true;
+            _executions[_id].executed = true;
 
             // solhint-disable-next-line avoid-low-level-calls
             (success,) = _executions[_id].to.call{value:(_executions[_id].value)}(_executions[_id].data);
 
             if (success) {
-                _executions[_id].executed = true;
-
                 emit Executed(
                     _id,
                     _executions[_id].to,

--- a/contracts/interface/IERC734.sol
+++ b/contracts/interface/IERC734.sol
@@ -87,7 +87,8 @@ interface IERC734 {
     /**
      * @dev Passes an execution instruction to an ERC734 identity.
      * How the execution is handled is up to the identity implementation:
-     * An execution COULD be requested and require `approve` to be called with one or more keys of purpose 1 or 2 to approve this execution.
+     * An execution COULD be requested and require `approve` to be called with one or more keys of purpose 1 or 2 to
+     * approve this execution.
      * Execute COULD be used as the only accessor for `addKey` and `removeKey`.
      *
      * Triggers Event: `ExecutionRequested`, `Executed`

--- a/contracts/interface/IERC734.sol
+++ b/contracts/interface/IERC734.sol
@@ -85,13 +85,12 @@ interface IERC734 {
     function removeKey(bytes32 _key, uint256 _purpose) external returns (bool success);
 
     /**
-     * @dev Passes an execution instruction to an ERC725 identity.
+     * @dev Passes an execution instruction to an ERC734 identity.
+     * How the execution is handled is up to the identity implementation:
+     * An execution COULD be requested and require `approve` to be called with one or more keys of purpose 1 or 2 to approve this execution.
+     * Execute COULD be used as the only accessor for `addKey` and `removeKey`.
      *
      * Triggers Event: `ExecutionRequested`, `Executed`
-     *
-     * Specification:
-     * SHOULD require approve to be called with one or more keys of purpose 1 or 2 to approve this execution.
-     * Execute COULD be used as the only accessor for `addKey` and `removeKey`.
      */
     function execute(address _to, uint256 _value, bytes calldata _data) external payable returns (uint256 executionId);
 

--- a/contracts/storage/Storage.sol
+++ b/contracts/storage/Storage.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 import "./Structs.sol";
 
 contract Storage is Structs {
+    uint256 internal _identifier;
 
     // nonce used by the execute/approve function
     uint256 internal _executionNonce;

--- a/test/onchainid.test.js
+++ b/test/onchainid.test.js
@@ -422,6 +422,14 @@ contract('ONCHAINID', (accounts) => {
         });
       });
 
+      describe('When not approving as a MANAGEMENT key', () => {
+        it('should be a no-op, leaving the approval status at false', async () => {
+          await user1Identity.approve(2, false, {
+            from: user1,
+          }).should.be.fulfilled;
+        });
+      });
+
       describe('When approving as a MANAGEMENT key', () => {
         it('should approve the execution', async () => {
           const currentBalance = await web3.eth.getBalance(user2);
@@ -442,6 +450,40 @@ contract('ONCHAINID', (accounts) => {
               .add(web3.utils.toBN('10'))
               .toString()
           );
+        });
+      });
+    });
+
+    describe('When approving with an execution ID that is not assigned yet', () => {
+      it('should revert for non-existing execution ID', async () => {
+        await user1Identity
+          .approve(100, true, {
+            from: user1,
+          })
+          .should.be.rejectedWith(EVMRevert);
+      });
+    });
+
+    describe('When executing an action over the identity itself', () => {
+      describe('When signing with an ACTION key', () => {
+        it('should revert the approval for non-authorized', async () => {
+          await user1Identity.execute(user1Identity.address, 0, '0x', {
+            from: unauthorizedAccount,
+          });
+
+          await user1Identity
+            .approve(3, true, {
+              from: user1ActionAccount,
+            })
+            .should.be.rejectedWith(EVMRevert);
+        });
+      });
+
+      describe('When signing with a MANAGEMENT key', () => {
+        it('should execute the pending request', async () => {
+          await user1Identity.approve(3, true, {
+            from: user1,
+          }).should.be.fulfilled;
         });
       });
     });

--- a/test/onchainid.test.js
+++ b/test/onchainid.test.js
@@ -538,6 +538,18 @@ contract('ONCHAINID', (accounts) => {
           ).should.eventually.be.true;
         });
       });
+
+      describe('When the execution should fail', () => {
+        it('should revert the approval', async () => {
+          await user1Identity.execute(user1Identity.address, 0, '0x001009473', {
+            from: user1ActionAccount,
+          });
+
+          await user1Identity
+            .approve(4, true, { from: user1 })
+            .should.be.rejectedWith('Execution failed.');
+        });
+      });
     });
   });
 });

--- a/test/onchainid.test.js
+++ b/test/onchainid.test.js
@@ -1,4 +1,5 @@
 require('chai').use(require('chai-as-promised')).should();
+
 const EVMRevert = require('./helpers/VMExceptionRevert');
 const {
   Factory,
@@ -25,6 +26,8 @@ contract('ONCHAINID', (accounts) => {
   const tokenFactory = accounts[4];
   const tokenOwner = accounts[5];
   const user1SecondaryWallet = accounts[6];
+  const user1ActionAccount = accounts[7];
+  const unauthorizedAccount = accounts[8];
   const token1 = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174';
   const token2 = '0xc2132D05D31c914a87C6611C10748AEb04B58e8F';
   const zeroAddress = '0x0000000000000000000000000000000000000000';
@@ -319,6 +322,128 @@ contract('ONCHAINID', (accounts) => {
         hexedData1
       );
       claimValidity.should.equal(false);
+    });
+  });
+
+  describe('Testing approve/execute', () => {
+    describe('When the sender is a MANAGEMENT key', () => {
+      it('should immediately approves the execution', async () => {
+        const currentBalance = await web3.eth.getBalance(user2);
+        await web3.eth
+          .getBalance(user1Identity.address)
+          .should.eventually.equal('0');
+        await user1Identity.execute(user2, 10, '0x', {
+          value: 10,
+          from: user1,
+        }).should.be.fulfilled;
+        const newBalance = await web3.eth.getBalance(user2);
+        newBalance.should.equal(
+          web3.utils.toBN(currentBalance).add(web3.utils.toBN('10')).toString()
+        );
+        await web3.eth
+          .getBalance(user1Identity.address)
+          .should.eventually.equal('0');
+      });
+    });
+
+    describe('When the sender is a ACTION key', () => {
+      it('should immediately approves the execution', async () => {
+        await user1Identity.addKey(
+          web3.utils.keccak256(
+            web3.eth.abi.encodeParameter('address', user1ActionAccount)
+          ),
+          2,
+          2,
+          { from: user1 }
+        );
+
+        const currentBalance = await web3.eth.getBalance(user2);
+        await web3.eth
+          .getBalance(user1Identity.address)
+          .should.eventually.equal('0');
+        await user1Identity.execute(user2, 10, '0x', {
+          value: 10,
+          from: user1ActionAccount,
+        }).should.be.fulfilled;
+        await web3.eth
+          .getBalance(user1Identity.address)
+          .should.eventually.equal('0');
+        const newBalance = await web3.eth.getBalance(user2);
+
+        newBalance.should.equal(
+          web3.utils.toBN(currentBalance).add(web3.utils.toBN('10')).toString()
+        );
+
+        await user1Identity.removeKey(
+          web3.utils.keccak256(
+            web3.eth.abi.encodeParameter('address', user1ActionAccount)
+          ),
+          2,
+          { from: user1 }
+        );
+      });
+    });
+
+    describe('When the sender is an unknown key', () => {
+      it('should store a pending approval', async () => {
+        const currentBalance = await web3.eth.getBalance(user1);
+        await web3.eth
+          .getBalance(user1Identity.address)
+          .should.eventually.equal('0');
+        await user1Identity.execute(user2, 10, '0x', {
+          from: user2,
+          value: 10,
+        }).should.be.fulfilled;
+        await web3.eth
+          .getBalance(user1Identity.address)
+          .should.eventually.equal('10');
+        const newBalance = await web3.eth.getBalance(user1);
+
+        newBalance.should.equal(currentBalance);
+      });
+
+      describe('When approving as an unauthorized key', () => {
+        it('should revert the approval', async () => {
+          const currentBalance = await web3.eth.getBalance(user2);
+          await web3.eth
+            .getBalance(user1Identity.address)
+            .should.eventually.equal('10');
+          await user1Identity
+            .approve(0, true, {
+              from: unauthorizedAccount,
+            })
+            .should.be.rejectedWith(EVMRevert);
+          await web3.eth
+            .getBalance(user1Identity.address)
+            .should.eventually.equal('10');
+          const newBalance = await web3.eth.getBalance(user2);
+
+          newBalance.should.equal(currentBalance);
+        });
+      });
+
+      describe('When approving as a MANAGEMENT key', () => {
+        it('should approve the execution', async () => {
+          const currentBalance = await web3.eth.getBalance(user2);
+          await web3.eth
+            .getBalance(user1Identity.address)
+            .should.eventually.equal('10');
+          await user1Identity.approve(2, true, {
+            from: user1,
+          }).should.be.fulfilled;
+          await web3.eth
+            .getBalance(user1Identity.address)
+            .should.eventually.equal('0');
+          const newBalance = await web3.eth.getBalance(user2);
+
+          newBalance.should.equal(
+            web3.utils
+              .toBN(currentBalance)
+              .add(web3.utils.toBN('10'))
+              .toString()
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
- The `approve` method now checks a `require(_id < _executionNonce, "Cannot approve a non-existing execution");`.
This effectively prevents calling `approve` on an execution nonce that was not request previously.
- An execution already executed successfully is now forbidden to be executed twice. An execution that was approved but failed to be executed can still be replayed in the current implementation. Implementation was updated to revert in case of a failure in the execution call, and the update to the execution.executed property made prior to the call to the destination of the execution.
- In the `execute` method, incrementing the value of the `_executionNonce++` is now made before the call to `approve` in case of auto-approved execution calls.