### PR TITLE
✨(IdFactory) Add method to deploy OID with management keys

### DIFF
--- a/contracts/factory/IIdFactory.sol
+++ b/contracts/factory/IIdFactory.sol
@@ -40,6 +40,24 @@ interface IIdFactory {
     function createIdentity(address _wallet, string memory _salt) external returns (address);
 
     /**
+     *  @dev function used to create a new Identity proxy from the factory, setting the wallet and listed keys as
+     * MANAGEMENT keys.
+     *  @param _wallet the wallet address of the primary owner of this ONCHAINID contract
+     *  @param _salt the salt used by create2 to issue the contract
+     *  @param _managementKeys A list of keys hash (keccak256(abiEncoded())) to add as MANAGEMENT keys.
+     *  requires a new salt for each deployment
+     *  _wallet cannot be linked to another ONCHAINID
+     *  only Owner can call => Owner is supposed to be a smart contract, managing the accessibility
+     *  of the function, including calls to oracles for multichain
+     *  deployment security (avoid identity theft), defining payment requirements, etc.
+     */
+    function createIdentityWithManagementKeys(
+        address _wallet,
+        string memory _salt,
+        bytes32[] memory _managementKeys
+    ) external returns (address);
+
+    /**
      *  @dev function used to create a new Token Identity proxy from the factory
      *  @param _token the address of the token contract
      *  @param _tokenOwner the owner address of the token


### PR DESCRIPTION
The current implementation of the OID Factory only allows the owner to deploy an identity with a single management key that is the wallet linked to this identity.

Many use-cases of ONCHAINID expects the deployer to add as well a key for their service on the identity. A new method `createIdentityWithManagementKeys(wallet, keys)` allows to deploy an Identity with the wallet as mangement key as usual, but also all the keys listed in the second parameter. Keys are expected to be hashed (`keccak256(abiEncoded())`).