### PR TITLE
✨ Add a Gateway to interact with the Factory

### DIFF
--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -26,7 +26,7 @@ error ExpiredSignature();
 /// Attempted to revoke a signature that was already revoked.
 error SignatureAlreadyRevoked();
 /// Attempted to approve a signature that was not revoked.
-error SignatureNotAlreadyRevoked();
+error SignatureNotRevoked();
 
 contract Gateway is Ownable {
     IdFactory private idFactory;
@@ -170,7 +170,7 @@ contract Gateway is Ownable {
      */
     function approveSignature(bytes calldata signature) external onlyOwner {
         if (!revokedSignatures[signature]) {
-            revert SignatureNotAlreadyRevoked();
+            revert SignatureNotRevoked();
         }
 
         delete revokedSignatures[signature];

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -64,6 +64,7 @@ contract Gateway is Ownable {
     /**
      *  @dev Approve a signer to sign ONCHAINID deployments. If the Gateway is setup to require signature, only
      *  deployments requested with a valid signature from an approved signer will be accepted.
+     *  If the gateway does not require a signature,
      *  @param signer the signer address to approve.
      */
     function approveSigner(address signer) external onlyOwner {
@@ -111,7 +112,7 @@ contract Gateway is Ownable {
         }
 
         if (requireSignatures) {
-            if (signatureExpiry < block.timestamp) {
+            if (signatureExpiry != 0 && signatureExpiry < block.timestamp) {
                 revert ExpiredSignature();
             }
 

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "../factory/IdFactory.sol";
+
+using ECDSA for bytes32;
+
+/// A required parameter was set to the Zero address.
+error ZeroAddress();
+/// The maximum number of signers was reached at deployment.
+error TooManySigners();
+/// The signed attempted to add was already approved.
+error SignerAlreadyApproved();
+/// The signed attempted to remove was not approved.
+error SignerAlreadyNotApproved();
+/// A requested ONCHAINID deployment was requested without a valid signature while the Gateway requires one.
+error UnsignedDeployment();
+/// A requested ONCHAINID deployment was requested and signer by a non approved signer.
+error UnapprovedSigner();
+/// A requested ONCHAINID deployment was requested with a signature revoked.
+error RevokedSignature();
+/// Attempted to revoke a signature that was already revoked.
+error SignatureAlreadyRevoked();
+/// Attempted to approve a signature that was not revoked.
+error SignatureNotAlreadyRevoked();
+
+contract Gateway is Ownable {
+    IdFactory private idFactory;
+    bool public requireSignatures;
+    mapping(address => bool) private approvedSigners;
+    mapping(bytes => bool) private revokedSignatures;
+
+    event SignerApproved(address signer);
+    event SignerRevoked(address signer);
+    event SignatureRevoked(bytes signature);
+    event SignatureApproved(bytes signature);
+
+    /**
+     *  @dev Constructor for the ONCHAINID Factory Gateway.
+     *  @param idFactoryAddress the address of the factory to operate (the Gateway must be owner of the Factory).
+     *  @param requireSignaturesToDeploy if true, the Gateway will require signatures from approved addresses to deploy
+     *  an ONCHAINID.
+     */
+    constructor(address idFactoryAddress, bool requireSignaturesToDeploy, address[] memory signersToApprove) Ownable() {
+        if (idFactoryAddress == address(0)) {
+            revert ZeroAddress();
+        }
+        if (signersToApprove.length > 10) {
+            revert TooManySigners();
+        }
+
+        for (uint i = 0; i < signersToApprove.length; i++) {
+            approvedSigners[signersToApprove[i]] = true;
+        }
+
+        idFactory = IdFactory(idFactoryAddress);
+        requireSignatures = requireSignaturesToDeploy;
+    }
+
+    /**
+     *  @dev Approve a signer to sign ONCHAINID deployments. If the Gateway is setup to require signature, only
+     *  deployments requested with a valid signature from an approved signer will be accepted.
+     *  @param signer the signer address to approve.
+     */
+    function approveSigner(address signer) external onlyOwner {
+        if (signer == address(0)) {
+            revert ZeroAddress();
+        }
+
+        if (approvedSigners[signer]) {
+            revert SignerAlreadyApproved();
+        }
+
+        approvedSigners[signer] = true;
+
+        emit SignerApproved(signer);
+    }
+
+    /**
+     *  @dev Revoke a signer to sign ONCHAINID deployments.
+     *  @param signer the signer address to revoke.
+     */
+    function revokeSigner(address signer) external onlyOwner {
+        if (signer == address(0)) {
+            revert ZeroAddress();
+        }
+
+        if (!approvedSigners[signer]) {
+            revert SignerAlreadyNotApproved();
+        }
+
+        delete approvedSigners[signer];
+
+        emit SignerRevoked(signer);
+    }
+
+    /**
+     *  @dev Deploy an ONCHAINID using a factory. Is the Gateway requires signatures, the transaction must be signed by
+     *  an approved public key.
+     *  @param identityOwner the address to set as a management key.
+     *  @param salt to use for the deployment.
+     *  @param signature the approval containing the salt and the identityOwner address.
+     */
+    function deployIdentity(address identityOwner, string memory salt, bytes calldata signature) external returns (address) {
+        if (identityOwner == address(0)) {
+            revert ZeroAddress();
+        }
+
+        if (requireSignatures) {
+            uint256 chainId;
+            assembly {
+                chainId := chainid()
+            }
+
+            address signer = ECDSA.recover(
+                keccak256(
+                    abi.encode(
+                        "Authorize ONCHAINID deployment",
+                        identityOwner,
+                        salt
+                    )
+                ).toEthSignedMessageHash(),
+                signature
+            );
+
+            if (!approvedSigners[signer]) {
+                revert UnapprovedSigner();
+            }
+
+            if (revokedSignatures[signature]) {
+                revert RevokedSignature();
+            }
+        }
+
+        return idFactory.createIdentity(identityOwner, salt);
+    }
+
+    /**
+     *  @dev Revoke a signature, if the signature is used to deploy an ONCHAINID, the deployment would be rejected.
+     *  @param signature the signature to revoke.
+     */
+    function revokeSignature(bytes calldata signature) external onlyOwner {
+        if (revokedSignatures[signature]) {
+            revert SignatureAlreadyRevoked();
+        }
+
+        revokedSignatures[signature] = true;
+
+        emit SignatureRevoked(signature);
+    }
+
+    /**
+     *  @dev Remove a signature from the revoke list.
+     *  @param signature the signature to approve.
+     */
+    function approveSignature(bytes calldata signature) external onlyOwner {
+        if (!revokedSignatures[signature]) {
+            revert SignatureNotAlreadyRevoked();
+        }
+
+        delete revokedSignatures[signature];
+
+        emit SignatureApproved(signature);
+    }
+}

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -150,7 +150,6 @@ contract Gateway is Ownable {
         return idFactory.createIdentity(identityOwner, Strings.toHexString(identityOwner));
     }
 
-
     /**
      *  @dev Revoke a signature, if the signature is used to deploy an ONCHAINID, the deployment would be rejected.
      *  @param signature the signature to revoke.
@@ -177,5 +176,13 @@ contract Gateway is Ownable {
         delete revokedSignatures[signature];
 
         emit SignatureApproved(signature);
+    }
+
+    /**
+     *  @dev Transfer the ownership of the factory to a new owner.
+     *  @param newOwner the new owner of the factory.
+     */
+    function transferFactoryOwnership(address newOwner) external onlyOwner {
+        idFactory.transferOwnership(newOwner);
     }
 }

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -29,9 +29,9 @@ error SignatureAlreadyRevoked();
 error SignatureNotRevoked();
 
 contract Gateway is Ownable {
-    IdFactory private idFactory;
-    mapping(address => bool) private approvedSigners;
-    mapping(bytes => bool) private revokedSignatures;
+    IdFactory public idFactory;
+    mapping(address => bool) public approvedSigners;
+    mapping(bytes => bool) public revokedSignatures;
 
     event SignerApproved(address signer);
     event SignerRevoked(address signer);
@@ -103,7 +103,12 @@ contract Gateway is Ownable {
      *  @param signatureExpiry the block timestamp where the signature will expire.
      *  @param signature the approval containing the salt and the identityOwner address.
      */
-    function deployIdentityWithSalt(address identityOwner, string memory salt, uint256 signatureExpiry, bytes calldata signature) external returns (address) {
+    function deployIdentityWithSalt(
+        address identityOwner,
+        string memory salt,
+        uint256 signatureExpiry,
+        bytes calldata signature
+    ) external returns (address) {
         if (identityOwner == address(0)) {
             revert ZeroAddress();
         }

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -206,4 +206,27 @@ describe.only('Gateway', () => {
       });
     });
   });
+
+  describe('.transferFactoryOwnership', () => {
+    describe('when called by the owner', () => {
+      it('should transfer ownership of the factory to the specified address', async () => {
+        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        await expect(gateway.transferFactoryOwnership(bobWallet.address)).to.emit(identityFactory, "OwnershipTransferred").withArgs(gateway.address, bobWallet.address);
+        expect(await identityFactory.owner()).to.be.equal(bobWallet.address);
+      });
+    });
+
+    describe('when not called by the owner', () => {
+      it('should revert', async () => {
+        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        await expect(gateway.connect(aliceWallet).transferFactoryOwnership(bobWallet.address)).to.be.revertedWith('Ownable: caller is not the owner')
+      });
+    });
+  });
 });

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -1,0 +1,105 @@
+import {ethers} from "hardhat";
+import {expect} from "chai";
+import {loadFixture} from "@nomicfoundation/hardhat-network-helpers";
+import {deployFactoryFixture} from "../fixtures";
+
+describe('Gateway', () => {
+  describe('constructor', () => {
+    describe('when factory address is not specified', () => {
+      it('should revert', async () => {
+        await expect(ethers.deployContract('Gateway', [ethers.constants.AddressZero, false, []])).to.be.reverted;
+      });
+    });
+  });
+
+  describe('.deployIdentity()', () => {
+    describe('when Gateway requires signature', () => {
+      describe('when signature is not valid', () => {
+        it('should revert with UnsignedDeployment', async () => {
+          const { identityFactory, aliceWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+
+          await expect(gateway.deployIdentity(aliceWallet.address, 'saltToUse', ethers.utils.randomBytes(65))).to.be.reverted;
+        });
+      });
+
+      describe('when signature is signed by a non authorized signer', () => {
+        it('should revert with UnsignedDeployment', async () => {
+          const { identityFactory, aliceWallet, bobWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+
+          await expect(
+            gateway.deployIdentity(
+              aliceWallet.address,
+              'saltToUse',
+              bobWallet.signMessage(
+                ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'string'], [aliceWallet.address, 'saltToUse'])),
+              ),
+            ),
+          ).to.be.revertedWithCustomError(gateway, 'UnapprovedSigner');
+        });
+      });
+
+      describe('when signature is correct and signed by an authorized signer', () => {
+        it('should deploy the identity', async () => {
+          const { identityFactory, aliceWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+          await identityFactory.transferOwnership(gateway.address);
+
+          const digest =
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                ['string', 'address', 'string'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse'],
+              ),
+          );
+          const signature = await carolWallet.signMessage(
+            ethers.utils.arrayify(
+              digest,
+            ),
+          );
+
+          const tx = await gateway.deployIdentity(
+            aliceWallet.address,
+            'saltToUse',
+            signature,
+          );
+          await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+          await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+          const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+          const identity = await ethers.getContractAt('Identity', identityAddress);
+          expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+        });
+      });
+
+      describe('when signature is correct and signed by an authorized signer, but revoked', () => {
+        it('should revert', async () => {
+          const { identityFactory, aliceWallet, bobWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+          await identityFactory.transferOwnership(gateway.address);
+
+          const digest =
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                ['string', 'address', 'string'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse'],
+              ),
+            );
+          const signature = await carolWallet.signMessage(
+            ethers.utils.arrayify(
+              digest,
+            ),
+          );
+
+          await gateway.revokeSignature(signature);
+
+          await expect(gateway.deployIdentity(
+            aliceWallet.address,
+            'saltToUse',
+            signature,
+          )).to.be.revertedWithCustomError(gateway, 'RevokedSignature');
+        });
+      });
+    });
+  });
+});

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -2,8 +2,9 @@ import {ethers} from "hardhat";
 import {expect} from "chai";
 import {loadFixture} from "@nomicfoundation/hardhat-network-helpers";
 import {deployFactoryFixture} from "../fixtures";
+import {BigNumber} from "ethers";
 
-describe('Gateway', () => {
+describe.only('Gateway', () => {
   describe('constructor', () => {
     describe('when factory address is not specified', () => {
       it('should revert', async () => {
@@ -16,24 +17,25 @@ describe('Gateway', () => {
     describe('when Gateway requires signature', () => {
       describe('when signature is not valid', () => {
         it('should revert with UnsignedDeployment', async () => {
-          const { identityFactory, aliceWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
           const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
 
-          await expect(gateway.deployIdentity(aliceWallet.address, 'saltToUse', ethers.utils.randomBytes(65))).to.be.reverted;
+          await expect(gateway.deployIdentity(aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60), ethers.utils.randomBytes(65))).to.be.reverted;
         });
       });
 
       describe('when signature is signed by a non authorized signer', () => {
         it('should revert with UnsignedDeployment', async () => {
-          const { identityFactory, aliceWallet, bobWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
           const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
 
           await expect(
             gateway.deployIdentity(
               aliceWallet.address,
               'saltToUse',
+              BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
               bobWallet.signMessage(
-                ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'string'], [aliceWallet.address, 'saltToUse'])),
+                ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['string', 'address', 'string', 'uint256'], ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)])),
               ),
             ),
           ).to.be.revertedWithCustomError(gateway, 'UnapprovedSigner');
@@ -42,17 +44,17 @@ describe('Gateway', () => {
 
       describe('when signature is correct and signed by an authorized signer', () => {
         it('should deploy the identity', async () => {
-          const { identityFactory, aliceWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
           const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
           await identityFactory.transferOwnership(gateway.address);
 
           const digest =
             ethers.utils.keccak256(
               ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse'],
+                ['string', 'address', 'string', 'uint256'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
               ),
-          );
+            );
           const signature = await carolWallet.signMessage(
             ethers.utils.arrayify(
               digest,
@@ -62,6 +64,7 @@ describe('Gateway', () => {
           const tx = await gateway.deployIdentity(
             aliceWallet.address,
             'saltToUse',
+            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
             signature,
           );
           await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
@@ -74,15 +77,15 @@ describe('Gateway', () => {
 
       describe('when signature is correct and signed by an authorized signer, but revoked', () => {
         it('should revert', async () => {
-          const { identityFactory, aliceWallet, bobWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
           const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
           await identityFactory.transferOwnership(gateway.address);
 
           const digest =
             ethers.utils.keccak256(
               ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse'],
+                ['string', 'address', 'string', 'uint256'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
               ),
             );
           const signature = await carolWallet.signMessage(
@@ -96,8 +99,39 @@ describe('Gateway', () => {
           await expect(gateway.deployIdentity(
             aliceWallet.address,
             'saltToUse',
+            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
             signature,
           )).to.be.revertedWithCustomError(gateway, 'RevokedSignature');
+        });
+      });
+
+      describe('when signature is correct and signed by an authorized signer, but has expired', () => {
+        it('should revert', async () => {
+          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+          await identityFactory.transferOwnership(gateway.address);
+
+          const digest =
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                ['string', 'address', 'string', 'uint256'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60)],
+              ),
+            );
+          const signature = await carolWallet.signMessage(
+            ethers.utils.arrayify(
+              digest,
+            ),
+          );
+
+          await gateway.revokeSignature(signature);
+
+          await expect(gateway.deployIdentity(
+            aliceWallet.address,
+            'saltToUse',
+            BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60),
+            signature,
+          )).to.be.revertedWithCustomError(gateway, 'ExpiredSignature');
         });
       });
     });

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -4,7 +4,7 @@ import {loadFixture} from "@nomicfoundation/hardhat-network-helpers";
 import {deployFactoryFixture} from "../fixtures";
 import {BigNumber} from "ethers";
 
-describe.only('Gateway', () => {
+describe('Gateway', () => {
   describe('constructor', () => {
     describe('when factory address is not specified', () => {
       it('should revert', async () => {

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -8,184 +8,201 @@ describe.only('Gateway', () => {
   describe('constructor', () => {
     describe('when factory address is not specified', () => {
       it('should revert', async () => {
-        await expect(ethers.deployContract('Gateway', [ethers.constants.AddressZero, false, []])).to.be.reverted;
+        await expect(ethers.deployContract('Gateway', [ethers.constants.AddressZero, []])).to.be.reverted;
       });
     });
   });
 
-  describe('.deployIdentity()', () => {
-    describe('when Gateway requires signature', () => {
-      describe('when signature is not valid', () => {
-        it('should revert with UnsignedDeployment', async () => {
-          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+  describe('.deployIdentityWithSalt()', () => {
+    describe('when signature is not valid', () => {
+      it('should revert with UnsignedDeployment', async () => {
+        const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
 
-          await expect(gateway.deployIdentity(aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60), ethers.utils.randomBytes(65))).to.be.reverted;
-        });
-      });
-
-      describe('when signature is signed by a non authorized signer', () => {
-        it('should revert with UnsignedDeployment', async () => {
-          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-
-          await expect(
-            gateway.deployIdentity(
-              aliceWallet.address,
-              'saltToUse',
-              BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
-              bobWallet.signMessage(
-                ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['string', 'address', 'string', 'uint256'], ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)])),
-              ),
-            ),
-          ).to.be.revertedWithCustomError(gateway, 'UnapprovedSigner');
-        });
-      });
-
-      describe('when signature is correct and signed by an authorized signer', () => {
-        it('should deploy the identity', async () => {
-          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-          await identityFactory.transferOwnership(gateway.address);
-
-          const digest =
-            ethers.utils.keccak256(
-              ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string', 'uint256'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
-              ),
-            );
-          const signature = await carolWallet.signMessage(
-            ethers.utils.arrayify(
-              digest,
-            ),
-          );
-
-          const tx = await gateway.deployIdentity(
-            aliceWallet.address,
-            'saltToUse',
-            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
-            signature,
-          );
-          await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
-          await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
-          const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
-          const identity = await ethers.getContractAt('Identity', identityAddress);
-          expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
-        });
-      });
-
-      describe('when signature is correct with no expiry', () => {
-        it('should deploy the identity', async () => {
-          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-          await identityFactory.transferOwnership(gateway.address);
-
-          const digest =
-            ethers.utils.keccak256(
-              ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string', 'uint256'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', 0],
-              ),
-            );
-          const signature = await carolWallet.signMessage(
-            ethers.utils.arrayify(
-              digest,
-            ),
-          );
-
-          const tx = await gateway.deployIdentity(
-            aliceWallet.address,
-            'saltToUse',
-            0,
-            signature,
-          );
-          await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
-          await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
-          const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
-          const identity = await ethers.getContractAt('Identity', identityAddress);
-          expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
-        });
-      });
-
-      describe('when signature is correct and signed by an authorized signer, but revoked', () => {
-        it('should revert', async () => {
-          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-          await identityFactory.transferOwnership(gateway.address);
-
-          const digest =
-            ethers.utils.keccak256(
-              ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string', 'uint256'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
-              ),
-            );
-          const signature = await carolWallet.signMessage(
-            ethers.utils.arrayify(
-              digest,
-            ),
-          );
-
-          await gateway.revokeSignature(signature);
-
-          await expect(gateway.deployIdentity(
-            aliceWallet.address,
-            'saltToUse',
-            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
-            signature,
-          )).to.be.revertedWithCustomError(gateway, 'RevokedSignature');
-        });
-      });
-
-      describe('when signature is correct and signed by an authorized signer, but has expired', () => {
-        it('should revert', async () => {
-          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-          await identityFactory.transferOwnership(gateway.address);
-
-          const digest =
-            ethers.utils.keccak256(
-              ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string', 'uint256'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60)],
-              ),
-            );
-          const signature = await carolWallet.signMessage(
-            ethers.utils.arrayify(
-              digest,
-            ),
-          );
-
-          await gateway.revokeSignature(signature);
-
-          await expect(gateway.deployIdentity(
-            aliceWallet.address,
-            'saltToUse',
-            BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60),
-            signature,
-          )).to.be.revertedWithCustomError(gateway, 'ExpiredSignature');
-        });
+        await expect(gateway.deployIdentityWithSalt(aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60), ethers.utils.randomBytes(65))).to.be.reverted;
       });
     });
 
-    describe('when gateway does not require a signature', () => {
-      it('should deploy an identity when requested', async () => {
-        const {identityFactory, aliceWallet} = await loadFixture(deployFactoryFixture);
-        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, false, []]);
+    describe('when signature is signed by a non authorized signer', () => {
+      it('should revert with UnsignedDeployment', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+
+        await expect(
+          gateway.deployIdentityWithSalt(
+            aliceWallet.address,
+            'saltToUse',
+            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
+            bobWallet.signMessage(
+              ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['string', 'address', 'string', 'uint256'], ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)])),
+            ),
+          ),
+        ).to.be.revertedWithCustomError(gateway, 'UnapprovedSigner');
+      });
+    });
+
+    describe('when signature is correct and signed by an authorized signer', () => {
+      it('should deploy the identity', async () => {
+        const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
-        const tx = await gateway.deployIdentity(
+        const digest =
+          ethers.utils.keccak256(
+            ethers.utils.defaultAbiCoder.encode(
+              ['string', 'address', 'string', 'uint256'],
+              ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
+            ),
+          );
+        const signature = await carolWallet.signMessage(
+          ethers.utils.arrayify(
+            digest,
+          ),
+        );
+
+        const tx = await gateway.deployIdentityWithSalt(
           aliceWallet.address,
           'saltToUse',
           BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
-          ethers.utils.randomBytes(65),
+          signature,
         );
         await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
         await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
         const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
         const identity = await ethers.getContractAt('Identity', identityAddress);
         expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+      });
+    });
+
+    describe('when signature is correct with no expiry', () => {
+      it('should deploy the identity', async () => {
+        const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        const digest =
+          ethers.utils.keccak256(
+            ethers.utils.defaultAbiCoder.encode(
+              ['string', 'address', 'string', 'uint256'],
+              ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', 0],
+            ),
+          );
+        const signature = await carolWallet.signMessage(
+          ethers.utils.arrayify(
+            digest,
+          ),
+        );
+
+        const tx = await gateway.deployIdentityWithSalt(
+          aliceWallet.address,
+          'saltToUse',
+          0,
+          signature,
+        );
+        await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+        await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+        const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+        const identity = await ethers.getContractAt('Identity', identityAddress);
+        expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+      });
+    });
+
+    describe('when signature is correct and signed by an authorized signer, but revoked', () => {
+      it('should revert', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        const digest =
+          ethers.utils.keccak256(
+            ethers.utils.defaultAbiCoder.encode(
+              ['string', 'address', 'string', 'uint256'],
+              ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
+            ),
+          );
+        const signature = await carolWallet.signMessage(
+          ethers.utils.arrayify(
+            digest,
+          ),
+        );
+
+        await gateway.revokeSignature(signature);
+
+        await expect(gateway.deployIdentityWithSalt(
+          aliceWallet.address,
+          'saltToUse',
+          BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
+          signature,
+        )).to.be.revertedWithCustomError(gateway, 'RevokedSignature');
+      });
+    });
+
+    describe('when signature is correct and signed by an authorized signer, but has expired', () => {
+      it('should revert', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        const digest =
+          ethers.utils.keccak256(
+            ethers.utils.defaultAbiCoder.encode(
+              ['string', 'address', 'string', 'uint256'],
+              ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60)],
+            ),
+          );
+        const signature = await carolWallet.signMessage(
+          ethers.utils.arrayify(
+            digest,
+          ),
+        );
+
+        await gateway.revokeSignature(signature);
+
+        await expect(gateway.deployIdentityWithSalt(
+          aliceWallet.address,
+          'saltToUse',
+          BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60),
+          signature,
+        )).to.be.revertedWithCustomError(gateway, 'ExpiredSignature');
+      });
+    });
+  });
+
+  describe('deployIdentityForWallet', () => {
+    describe('when sender is not the desired identity owner', () => {
+      it('should revert', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+        await expect(gateway.deployIdentityForWallet(aliceWallet.address)).to.revertedWithCustomError(gateway, 'UnapprovedSigner');
+      });
+    });
+
+    describe('when an identity was not yet deployed for this walet', () => {
+      it('should deploy the identity', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+        const tx = await gateway.connect(aliceWallet).deployIdentityForWallet(aliceWallet.address);
+
+        await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+        await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+        const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+        const identity = await ethers.getContractAt('Identity', identityAddress);
+
+        expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+      });
+    });
+
+    describe('when an identity was already deployed for this wallet as salt with the factory', () => {
+      it('should revert because factory reverts', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        await gateway.connect(aliceWallet).deployIdentityForWallet(aliceWallet.address);
+
+        await expect(gateway.connect(aliceWallet).deployIdentityForWallet(aliceWallet.address)).to.be.revertedWith('salt already taken');
       });
     });
   });

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -75,6 +75,39 @@ describe.only('Gateway', () => {
         });
       });
 
+      describe('when signature is correct with no expiry', () => {
+        it('should deploy the identity', async () => {
+          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+          await identityFactory.transferOwnership(gateway.address);
+
+          const digest =
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                ['string', 'address', 'string', 'uint256'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', 0],
+              ),
+            );
+          const signature = await carolWallet.signMessage(
+            ethers.utils.arrayify(
+              digest,
+            ),
+          );
+
+          const tx = await gateway.deployIdentity(
+            aliceWallet.address,
+            'saltToUse',
+            0,
+            signature,
+          );
+          await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+          await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+          const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+          const identity = await ethers.getContractAt('Identity', identityAddress);
+          expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+        });
+      });
+
       describe('when signature is correct and signed by an authorized signer, but revoked', () => {
         it('should revert', async () => {
           const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
@@ -133,6 +166,26 @@ describe.only('Gateway', () => {
             signature,
           )).to.be.revertedWithCustomError(gateway, 'ExpiredSignature');
         });
+      });
+    });
+
+    describe('when gateway does not require a signature', () => {
+      it('should deploy an identity when requested', async () => {
+        const {identityFactory, aliceWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, false, []]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        const tx = await gateway.deployIdentity(
+          aliceWallet.address,
+          'saltToUse',
+          BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
+          ethers.utils.randomBytes(65),
+        );
+        await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+        await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+        const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+        const identity = await ethers.getContractAt('Identity', identityAddress);
+        expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
       });
     });
   });


### PR DESCRIPTION
Add a Gateway contract to interact with the Factory, the Gateway is designed to be Owner of the Factory and only authorize senders to deploy identities using their own address as the salt. To deploy an identity using a custom salt, a signature from a list of approved signers is required.

See docs in https://github.com/onchain-id/documentation/pull/58