### PR TITLE
✨ Add Verifier contract

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,5 @@
+module.exports = {
+    skipFiles: [
+        "_testContracts",
+    ],
+};

--- a/.solhint.json
+++ b/.solhint.json
@@ -18,7 +18,7 @@
     "imports-on-top": "error",
     "ordering": "error",
     "visibility-modifier-order": "error",
-    "code-complexity": ["error", 7],
+    "code-complexity": ["error", 11],
     "function-max-lines": ["error", 50],
     "max-line-length": ["error", 130],
     "max-states-count": ["error", 15],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### Added
+- Implemented a new contract `Gateway` to interact with the `IdFactory`. The `Gateway` contract allows individual
+accounts (being EOA or contracts) to deploy identities for their own address as a salt. To deploy using
+a custom salt, a signature from an approved signer is required.
+- Implemented a new base contract `Verifier` to be extended by contract requiring identity verification based on claims
+and trusted issuers.
+
 ## [2.0.1]
 
 ### Added

--- a/contracts/_testContracts/VerifierUser.sol
+++ b/contracts/_testContracts/VerifierUser.sol
@@ -1,3 +1,5 @@
+/* solhint-disable */
+
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 

--- a/contracts/_testContracts/VerifierUser.sol
+++ b/contracts/_testContracts/VerifierUser.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.17;
+
+import "../verifiers/Verifier.sol";
+
+contract VerifierUser is Verifier {
+    constructor() Verifier() {}
+
+    function doSomething() onlyVerifiedSender public {}
+}

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -26,7 +26,7 @@ error ExpiredSignature();
 /// Attempted to revoke a signature that was already revoked.
 error SignatureAlreadyRevoked();
 /// Attempted to approve a signature that was not revoked.
-error SignatureNotAlreadyRevoked();
+error SignatureNotRevoked();
 
 contract Gateway is Ownable {
     IdFactory private idFactory;
@@ -170,7 +170,7 @@ contract Gateway is Ownable {
      */
     function approveSignature(bytes calldata signature) external onlyOwner {
         if (!revokedSignatures[signature]) {
-            revert SignatureNotAlreadyRevoked();
+            revert SignatureNotRevoked();
         }
 
         delete revokedSignatures[signature];

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -140,6 +140,17 @@ contract Gateway is Ownable {
         return idFactory.createIdentity(identityOwner, salt);
     }
 
+    /**
+     *  @dev Deploy an ONCHAINID using a factory. The operation must be signed by
+     *  an approved public key. This method allow to deploy an ONCHAINID using a custom salt and a custom list of
+     *  management keys. Note that the identity Owner address won't be added as a management keys, if this is desired,
+     *  the key hash must be listed in the managementKeys array.
+     *  @param identityOwner the address to set as a management key.
+     *  @param salt to use for the deployment.
+     *  @param managementKeys the list of management keys to add to the ONCHAINID.
+     *  @param signatureExpiry the block timestamp where the signature will expire.
+     *  @param signature the approval containing the salt and the identityOwner address.
+     */
     function deployIdentityWithSaltAndManagementKeys(
         address identityOwner,
         string memory salt,

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -190,4 +190,13 @@ contract Gateway is Ownable {
     function transferFactoryOwnership(address newOwner) external onlyOwner {
         idFactory.transferOwnership(newOwner);
     }
+
+    /**
+     *  @dev Call a function on the factory. Only the owner of the Gateway can call this method.
+     *  @param data the data to call on the factory.
+     */
+    function callFactory(bytes memory data) external onlyOwner {
+        (bool success,) = address(idFactory).call(data);
+        require(success, "Gateway: call to factory failed");
+    }
 }

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -64,6 +64,7 @@ contract Gateway is Ownable {
     /**
      *  @dev Approve a signer to sign ONCHAINID deployments. If the Gateway is setup to require signature, only
      *  deployments requested with a valid signature from an approved signer will be accepted.
+     *  If the gateway does not require a signature,
      *  @param signer the signer address to approve.
      */
     function approveSigner(address signer) external onlyOwner {
@@ -111,7 +112,7 @@ contract Gateway is Ownable {
         }
 
         if (requireSignatures) {
-            if (signatureExpiry < block.timestamp) {
+            if (signatureExpiry != 0 && signatureExpiry < block.timestamp) {
                 revert ExpiredSignature();
             }
 

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "../factory/IdFactory.sol";
+
+using ECDSA for bytes32;
+
+/// A required parameter was set to the Zero address.
+error ZeroAddress();
+/// The maximum number of signers was reached at deployment.
+error TooManySigners();
+/// The signed attempted to add was already approved.
+error SignerAlreadyApproved();
+/// The signed attempted to remove was not approved.
+error SignerAlreadyNotApproved();
+/// A requested ONCHAINID deployment was requested without a valid signature while the Gateway requires one.
+error UnsignedDeployment();
+/// A requested ONCHAINID deployment was requested and signer by a non approved signer.
+error UnapprovedSigner();
+/// A requested ONCHAINID deployment was requested with a signature revoked.
+error RevokedSignature();
+/// Attempted to revoke a signature that was already revoked.
+error SignatureAlreadyRevoked();
+/// Attempted to approve a signature that was not revoked.
+error SignatureNotAlreadyRevoked();
+
+contract Gateway is Ownable {
+    IdFactory private idFactory;
+    bool public requireSignatures;
+    mapping(address => bool) private approvedSigners;
+    mapping(bytes => bool) private revokedSignatures;
+
+    event SignerApproved(address signer);
+    event SignerRevoked(address signer);
+    event SignatureRevoked(bytes signature);
+    event SignatureApproved(bytes signature);
+
+    /**
+     *  @dev Constructor for the ONCHAINID Factory Gateway.
+     *  @param idFactoryAddress the address of the factory to operate (the Gateway must be owner of the Factory).
+     *  @param requireSignaturesToDeploy if true, the Gateway will require signatures from approved addresses to deploy
+     *  an ONCHAINID.
+     */
+    constructor(address idFactoryAddress, bool requireSignaturesToDeploy, address[] memory signersToApprove) Ownable() {
+        if (idFactoryAddress == address(0)) {
+            revert ZeroAddress();
+        }
+        if (signersToApprove.length > 10) {
+            revert TooManySigners();
+        }
+
+        for (uint i = 0; i < signersToApprove.length; i++) {
+            approvedSigners[signersToApprove[i]] = true;
+        }
+
+        idFactory = IdFactory(idFactoryAddress);
+        requireSignatures = requireSignaturesToDeploy;
+    }
+
+    /**
+     *  @dev Approve a signer to sign ONCHAINID deployments. If the Gateway is setup to require signature, only
+     *  deployments requested with a valid signature from an approved signer will be accepted.
+     *  @param signer the signer address to approve.
+     */
+    function approveSigner(address signer) external onlyOwner {
+        if (signer == address(0)) {
+            revert ZeroAddress();
+        }
+
+        if (approvedSigners[signer]) {
+            revert SignerAlreadyApproved();
+        }
+
+        approvedSigners[signer] = true;
+
+        emit SignerApproved(signer);
+    }
+
+    /**
+     *  @dev Revoke a signer to sign ONCHAINID deployments.
+     *  @param signer the signer address to revoke.
+     */
+    function revokeSigner(address signer) external onlyOwner {
+        if (signer == address(0)) {
+            revert ZeroAddress();
+        }
+
+        if (!approvedSigners[signer]) {
+            revert SignerAlreadyNotApproved();
+        }
+
+        delete approvedSigners[signer];
+
+        emit SignerRevoked(signer);
+    }
+
+    /**
+     *  @dev Deploy an ONCHAINID using a factory. Is the Gateway requires signatures, the transaction must be signed by
+     *  an approved public key.
+     *  @param identityOwner the address to set as a management key.
+     *  @param salt to use for the deployment.
+     *  @param signature the approval containing the salt and the identityOwner address.
+     */
+    function deployIdentity(address identityOwner, string memory salt, bytes calldata signature) external returns (address) {
+        if (identityOwner == address(0)) {
+            revert ZeroAddress();
+        }
+
+        if (requireSignatures) {
+            uint256 chainId;
+            assembly {
+                chainId := chainid()
+            }
+
+            address signer = ECDSA.recover(
+                keccak256(
+                    abi.encode(
+                        "Authorize ONCHAINID deployment",
+                        identityOwner,
+                        salt
+                    )
+                ).toEthSignedMessageHash(),
+                signature
+            );
+
+            if (!approvedSigners[signer]) {
+                revert UnapprovedSigner();
+            }
+
+            if (revokedSignatures[signature]) {
+                revert RevokedSignature();
+            }
+        }
+
+        return idFactory.createIdentity(identityOwner, salt);
+    }
+
+    /**
+     *  @dev Revoke a signature, if the signature is used to deploy an ONCHAINID, the deployment would be rejected.
+     *  @param signature the signature to revoke.
+     */
+    function revokeSignature(bytes calldata signature) external onlyOwner {
+        if (revokedSignatures[signature]) {
+            revert SignatureAlreadyRevoked();
+        }
+
+        revokedSignatures[signature] = true;
+
+        emit SignatureRevoked(signature);
+    }
+
+    /**
+     *  @dev Remove a signature from the revoke list.
+     *  @param signature the signature to approve.
+     */
+    function approveSignature(bytes calldata signature) external onlyOwner {
+        if (!revokedSignatures[signature]) {
+            revert SignatureNotAlreadyRevoked();
+        }
+
+        delete revokedSignatures[signature];
+
+        emit SignatureApproved(signature);
+    }
+}

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -150,7 +150,6 @@ contract Gateway is Ownable {
         return idFactory.createIdentity(identityOwner, Strings.toHexString(identityOwner));
     }
 
-
     /**
      *  @dev Revoke a signature, if the signature is used to deploy an ONCHAINID, the deployment would be rejected.
      *  @param signature the signature to revoke.
@@ -177,5 +176,13 @@ contract Gateway is Ownable {
         delete revokedSignatures[signature];
 
         emit SignatureApproved(signature);
+    }
+
+    /**
+     *  @dev Transfer the ownership of the factory to a new owner.
+     *  @param newOwner the new owner of the factory.
+     */
+    function transferFactoryOwnership(address newOwner) external onlyOwner {
+        idFactory.transferOwnership(newOwner);
     }
 }

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -29,9 +29,9 @@ error SignatureAlreadyRevoked();
 error SignatureNotRevoked();
 
 contract Gateway is Ownable {
-    IdFactory private idFactory;
-    mapping(address => bool) private approvedSigners;
-    mapping(bytes => bool) private revokedSignatures;
+    IdFactory public idFactory;
+    mapping(address => bool) public approvedSigners;
+    mapping(bytes => bool) public revokedSignatures;
 
     event SignerApproved(address signer);
     event SignerRevoked(address signer);
@@ -103,7 +103,12 @@ contract Gateway is Ownable {
      *  @param signatureExpiry the block timestamp where the signature will expire.
      *  @param signature the approval containing the salt and the identityOwner address.
      */
-    function deployIdentityWithSalt(address identityOwner, string memory salt, uint256 signatureExpiry, bytes calldata signature) external returns (address) {
+    function deployIdentityWithSalt(
+        address identityOwner,
+        string memory salt,
+        uint256 signatureExpiry,
+        bytes calldata signature
+    ) external returns (address) {
         if (identityOwner == address(0)) {
             revert ZeroAddress();
         }

--- a/contracts/gateway/Gateway.sol
+++ b/contracts/gateway/Gateway.sol
@@ -33,10 +33,10 @@ contract Gateway is Ownable {
     mapping(address => bool) public approvedSigners;
     mapping(bytes => bool) public revokedSignatures;
 
-    event SignerApproved(address signer);
-    event SignerRevoked(address signer);
-    event SignatureRevoked(bytes signature);
-    event SignatureApproved(bytes signature);
+    event SignerApproved(address indexed signer);
+    event SignerRevoked(address indexed signer);
+    event SignatureRevoked(bytes indexed signature);
+    event SignatureApproved(bytes indexed signature);
 
     /**
      *  @dev Constructor for the ONCHAINID Factory Gateway.

--- a/contracts/verifiers/Verifier.sol
+++ b/contracts/verifiers/Verifier.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../interface/IClaimIssuer.sol";
+
+contract Verifier is Ownable {
+    /**
+     *  this event is emitted when a claim topic has been added to the requirement list
+     *  the event is emitted by the 'addClaimTopic' function
+     *  `claimTopic` is the required claim topic added
+     */
+    event ClaimTopicAdded(uint256 indexed claimTopic);
+
+    /**
+     *  this event is emitted when a claim topic has been removed from the requirement list
+     *  the event is emitted by the 'removeClaimTopic' function
+     *  `claimTopic` is the required claim removed
+     */
+    event ClaimTopicRemoved(uint256 indexed claimTopic);
+
+    /**
+     *  this event is emitted when an issuer is added to the trusted list.
+     *  the event is emitted by the addTrustedIssuer function
+     *  `trustedIssuer` is the address of the trusted issuer's ClaimIssuer contract
+     *  `claimTopics` is the set of claims that the trusted issuer is allowed to emit
+     */
+    event TrustedIssuerAdded(IClaimIssuer indexed trustedIssuer, uint256[] claimTopics);
+
+    /**
+     *  this event is emitted when an issuer is removed from the trusted list.
+     *  the event is emitted by the removeTrustedIssuer function
+     *  `trustedIssuer` is the address of the trusted issuer's ClaimIssuer contract
+     */
+    event TrustedIssuerRemoved(IClaimIssuer indexed trustedIssuer);
+
+    /**
+     *  this event is emitted when the set of claim topics is changed for a given trusted issuer.
+     *  the event is emitted by the updateIssuerClaimTopics function
+     *  `trustedIssuer` is the address of the trusted issuer's ClaimIssuer contract
+     *  `claimTopics` is the set of claims that the trusted issuer is allowed to emit
+     */
+    event ClaimTopicsUpdated(IClaimIssuer indexed trustedIssuer, uint256[] claimTopics);
+
+    /// @dev All topics of claims required to pass verification.
+    uint256[] public requiredClaimTopics;
+
+    /// @dev Array containing all TrustedIssuers identity contract address allowed to issue claims required.
+    IClaimIssuer[] public trustedIssuers;
+
+    /// @dev Mapping between a trusted issuer address and the topics of claims they are trusted for.
+    mapping(address => uint256[]) public trustedIssuerClaimTopics;
+
+    /// @dev Mapping between a claim topic and the trusted issuers trusted for it.
+    mapping(uint256 => IClaimIssuer[]) public claimTopicsToTrustedIssuers;
+
+
+    modifier onlyVerifiedSender() {
+        require(verify(_msgSender()), "sender is not verified");
+        _;
+    }
+
+
+    constructor() Ownable() {}
+
+    /**
+     * @dev Verify an identity (ONCHAINID) by checking if the identity has at least one valid claim from a trusted
+     * issuer for each required claim topic. Returns true if the identity is compliant, false otherwise.
+     */
+    function verify(address identity) public view returns(bool isVerified) {
+        if (requiredClaimTopics.length == 0) {
+            return true;
+        }
+
+        uint256 foundClaimTopic;
+        uint256 scheme;
+        address issuer;
+        bytes memory sig;
+        bytes memory data;
+        uint256 claimTopic;
+        for (claimTopic = 0; claimTopic < requiredClaimTopics.length; claimTopic++) {
+            IClaimIssuer[] memory trustedIssuersForClaimTopic = this.getTrustedIssuersForClaimTopic(requiredClaimTopics[claimTopic]);
+
+            if (trustedIssuersForClaimTopic.length == 0) {
+                return false;
+            }
+
+            bytes32[] memory claimIds = new bytes32[](trustedIssuersForClaimTopic.length);
+            for (uint256 i = 0; i < trustedIssuersForClaimTopic.length; i++) {
+                claimIds[i] = keccak256(abi.encode(trustedIssuersForClaimTopic[i], requiredClaimTopics[claimTopic]));
+            }
+
+            for (uint256 j = 0; j < claimIds.length; j++) {
+                (foundClaimTopic, scheme, issuer, sig, data, ) = IIdentity(identity).getClaim(claimIds[j]);
+
+                if (foundClaimTopic == requiredClaimTopics[claimTopic]) {
+                    try IClaimIssuer(issuer).isClaimValid(IIdentity(identity), requiredClaimTopics[claimTopic], sig,
+                        data) returns(bool _validity) {
+
+                        if (
+                            _validity
+                        ) {
+                            j = claimIds.length;
+                        }
+                        if (!_validity && j == (claimIds.length - 1)) {
+                            return false;
+                        }
+                    } catch {
+                        if (j == (claimIds.length - 1)) {
+                            return false;
+                        }
+                    }
+                } else if (j == (claimIds.length - 1)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     *  @dev See {IClaimTopicsRegistry-removeClaimTopic}.
+     */
+    function addClaimTopic(uint256 claimTopic) public onlyOwner {
+        uint256 length = requiredClaimTopics.length;
+        require(length < 15, "cannot require more than 15 topics");
+        for (uint256 i = 0; i < length; i++) {
+            require(requiredClaimTopics[i] != claimTopic, "claimTopic already exists");
+        }
+        requiredClaimTopics.push(claimTopic);
+        emit ClaimTopicAdded(claimTopic);
+    }
+
+    /**
+     *  @dev See {IClaimTopicsRegistry-getClaimTopics}.
+     */
+    function removeClaimTopic(uint256 claimTopic) public onlyOwner {
+        uint256 length = requiredClaimTopics.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (requiredClaimTopics[i] == claimTopic) {
+                requiredClaimTopics[i] = requiredClaimTopics[length - 1];
+                requiredClaimTopics.pop();
+                emit ClaimTopicRemoved(claimTopic);
+                break;
+            }
+        }
+    }
+
+    /**
+     *  @dev See {ITrustedIssuersRegistry-addTrustedIssuer}.
+     */
+    function addTrustedIssuer(IClaimIssuer trustedIssuer, uint256[] calldata claimTopics) public onlyOwner {
+        require(address(trustedIssuer) != address(0), "invalid argument - zero address");
+        require(trustedIssuerClaimTopics[address(trustedIssuer)].length == 0, "trusted Issuer already exists");
+        require(claimTopics.length > 0, "trusted claim topics cannot be empty");
+        require(claimTopics.length <= 15, "cannot have more than 15 claim topics");
+        require(trustedIssuers.length < 50, "cannot have more than 50 trusted issuers");
+        trustedIssuers.push(trustedIssuer);
+        trustedIssuerClaimTopics[address(trustedIssuer)] = claimTopics;
+        for (uint256 i = 0; i < claimTopics.length; i++) {
+            claimTopicsToTrustedIssuers[claimTopics[i]].push(trustedIssuer);
+        }
+        emit TrustedIssuerAdded(trustedIssuer, claimTopics);
+    }
+
+    /**
+     *  @dev See {ITrustedIssuersRegistry-removeTrustedIssuer}.
+     */
+    function removeTrustedIssuer(IClaimIssuer trustedIssuer) public onlyOwner {
+        require(address(trustedIssuer) != address(0), "invalid argument - zero address");
+        require(trustedIssuerClaimTopics[address(trustedIssuer)].length != 0, "NOT a trusted issuer");
+        uint256 length = trustedIssuers.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (trustedIssuers[i] == trustedIssuer) {
+                trustedIssuers[i] = trustedIssuers[length - 1];
+                trustedIssuers.pop();
+                break;
+            }
+        }
+        for (
+            uint256 claimTopicIndex = 0;
+            claimTopicIndex < trustedIssuerClaimTopics[address(trustedIssuer)].length;
+            claimTopicIndex++) {
+            uint256 claimTopic = trustedIssuerClaimTopics[address(trustedIssuer)][claimTopicIndex];
+            uint256 topicsLength = claimTopicsToTrustedIssuers[claimTopic].length;
+            for (uint256 i = 0; i < topicsLength; i++) {
+                if (claimTopicsToTrustedIssuers[claimTopic][i] == trustedIssuer) {
+                    claimTopicsToTrustedIssuers[claimTopic][i] =
+                                        claimTopicsToTrustedIssuers[claimTopic][topicsLength - 1];
+                    claimTopicsToTrustedIssuers[claimTopic].pop();
+                    break;
+                }
+            }
+        }
+        delete trustedIssuerClaimTopics[address(trustedIssuer)];
+        emit TrustedIssuerRemoved(trustedIssuer);
+    }
+
+    /**
+     *  @dev See {ITrustedIssuersRegistry-updateIssuerClaimTopics}.
+     */
+    function updateIssuerClaimTopics(IClaimIssuer trustedIssuer, uint256[] calldata newClaimTopics) public onlyOwner {
+        require(address(trustedIssuer) != address(0), "invalid argument - zero address");
+        require(trustedIssuerClaimTopics[address(trustedIssuer)].length != 0, "NOT a trusted issuer");
+        require(newClaimTopics.length <= 15, "cannot have more than 15 claim topics");
+        require(newClaimTopics.length > 0, "claim topics cannot be empty");
+
+        for (uint256 i = 0; i < trustedIssuerClaimTopics[address(trustedIssuer)].length; i++) {
+            uint256 claimTopic = trustedIssuerClaimTopics[address(trustedIssuer)][i];
+            uint256 topicsLength = claimTopicsToTrustedIssuers[claimTopic].length;
+            for (uint256 j = 0; j < topicsLength; j++) {
+                if (claimTopicsToTrustedIssuers[claimTopic][j] == trustedIssuer) {
+                    claimTopicsToTrustedIssuers[claimTopic][j] =
+                                        claimTopicsToTrustedIssuers[claimTopic][topicsLength - 1];
+                    claimTopicsToTrustedIssuers[claimTopic].pop();
+                    break;
+                }
+            }
+        }
+        trustedIssuerClaimTopics[address(trustedIssuer)] = newClaimTopics;
+        for (uint256 i = 0; i < newClaimTopics.length; i++) {
+            claimTopicsToTrustedIssuers[newClaimTopics[i]].push(trustedIssuer);
+        }
+        emit ClaimTopicsUpdated(trustedIssuer, newClaimTopics);
+    }
+
+    /**
+     *  @dev See {ITrustedIssuersRegistry-getTrustedIssuers}.
+     */
+    function getTrustedIssuers() public view returns (IClaimIssuer[] memory) {
+        return trustedIssuers;
+    }
+
+    /**
+     *  @dev See {ITrustedIssuersRegistry-getTrustedIssuersForClaimTopic}.
+     */
+    function getTrustedIssuersForClaimTopic(uint256 claimTopic) public view returns (IClaimIssuer[] memory) {
+        return claimTopicsToTrustedIssuers[claimTopic];
+    }
+
+    /**
+     *  @dev See {ITrustedIssuersRegistry-isTrustedIssuer}.
+     */
+    function isTrustedIssuer(address issuer) public view returns (bool) {
+        if(trustedIssuerClaimTopics[issuer].length > 0) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *  @dev See {ITrustedIssuersRegistry-getTrustedIssuerClaimTopics}.
+     */
+    function getTrustedIssuerClaimTopics(IClaimIssuer trustedIssuer) public view returns (uint256[] memory) {
+        require(trustedIssuerClaimTopics[address(trustedIssuer)].length != 0, "trusted Issuer doesn\'t exist");
+        return trustedIssuerClaimTopics[address(trustedIssuer)];
+    }
+
+    /**
+     *  @dev See {ITrustedIssuersRegistry-hasClaimTopic}.
+     */
+    function hasClaimTopic(address issuer, uint256 claimTopic) public view returns (bool) {
+        uint256[] memory claimTopics = trustedIssuerClaimTopics[issuer];
+        uint256 length = claimTopics.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (claimTopics[i] == claimTopic) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function isClaimTopicRequired(uint256 claimTopic) public view returns (bool) {
+        uint256 length = requiredClaimTopics.length;
+
+        for (uint256 i = 0; i < length; i++) {
+            if (requiredClaimTopics[i] == claimTopic) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,11 @@
 export namespace contracts {
   export const ClaimIssuer: any;
+  export const Gateway: any;
   export const Identity: any;
   export const ImplementationAuthority: any;
   export const IdentityProxy: any;
   export const Factory: any;
+  export const Verifier: any;
 }
 
 export namespace interfaces {

--- a/index.js
+++ b/index.js
@@ -7,19 +7,23 @@ const IImplementationAuthority = require('./artifacts/contracts/interface/IImple
 
 const ClaimIssuer = require('./artifacts/contracts/ClaimIssuer.sol/ClaimIssuer.json');
 const Factory = require('./artifacts/contracts/factory/IdFactory.sol/IdFactory.json');
+const Gateway = require('./artifacts/contracts/gateway/Gateway.sol/Gateway.json');
 const Identity = require('./artifacts/contracts/Identity.sol/Identity.json');
 const ImplementationAuthority = require('./artifacts/contracts/proxy/ImplementationAuthority.sol/ImplementationAuthority.json');
 const IdentityProxy = require('./artifacts/contracts/proxy/IdentityProxy.sol/IdentityProxy.json');
+const Verifier = require('./artifacts/contracts/verifiers/Verifier.sol/Verifier.json');
 const Version = require('./artifacts/contracts/version/Version.sol/Version.json');
 
 module.exports = {
   contracts: {
     ClaimIssuer,
+    Factory,
+    Gateway,
     Identity,
     ImplementationAuthority,
     IdentityProxy,
     Version,
-    Factory,
+    Verifier,
   },
   interfaces: {
     IClaimIssuer,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.1.0-beta4",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.1.0-beta1",
+  "version": "2.1.0-beta2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.1.0-beta2",
+  "version": "2.1.0-beta3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.1.0-beta3",
+  "version": "2.1.0-beta4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.0.1",
+  "version": "2.1.0-beta1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.1.0-beta3",
+  "version": "2.1.0-beta4",
   "description": "EVM solidity smart contracts for Blockchain OnchainID identities.",
   "files": [
     "artifacts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.1.0-beta4",
+  "version": "2.1.0",
   "description": "EVM solidity smart contracts for Blockchain OnchainID identities.",
   "files": [
     "artifacts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.0.1",
+  "version": "2.1.0-beta1",
   "description": "EVM solidity smart contracts for Blockchain OnchainID identities.",
   "files": [
     "artifacts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.1.0-beta2",
+  "version": "2.1.0-beta3",
   "description": "EVM solidity smart contracts for Blockchain OnchainID identities.",
   "files": [
     "artifacts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.1.0-beta1",
+  "version": "2.1.0-beta2",
   "description": "EVM solidity smart contracts for Blockchain OnchainID identities.",
   "files": [
     "artifacts",

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -95,3 +95,7 @@ export async function deployIdentityFixture() {
     tokenAddress
   };
 }
+
+export async function deployVerifierFixture() {
+
+}

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -206,4 +206,27 @@ describe.only('Gateway', () => {
       });
     });
   });
+
+  describe('.transferFactoryOwnership', () => {
+    describe('when called by the owner', () => {
+      it('should transfer ownership of the factory to the specified address', async () => {
+        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        await expect(gateway.transferFactoryOwnership(bobWallet.address)).to.emit(identityFactory, "OwnershipTransferred").withArgs(gateway.address, bobWallet.address);
+        expect(await identityFactory.owner()).to.be.equal(bobWallet.address);
+      });
+    });
+
+    describe('when not called by the owner', () => {
+      it('should revert', async () => {
+        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        await expect(gateway.connect(aliceWallet).transferFactoryOwnership(bobWallet.address)).to.be.revertedWith('Ownable: caller is not the owner')
+      });
+    });
+  });
 });

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -1,0 +1,105 @@
+import {ethers} from "hardhat";
+import {expect} from "chai";
+import {loadFixture} from "@nomicfoundation/hardhat-network-helpers";
+import {deployFactoryFixture} from "../fixtures";
+
+describe('Gateway', () => {
+  describe('constructor', () => {
+    describe('when factory address is not specified', () => {
+      it('should revert', async () => {
+        await expect(ethers.deployContract('Gateway', [ethers.constants.AddressZero, false, []])).to.be.reverted;
+      });
+    });
+  });
+
+  describe('.deployIdentity()', () => {
+    describe('when Gateway requires signature', () => {
+      describe('when signature is not valid', () => {
+        it('should revert with UnsignedDeployment', async () => {
+          const { identityFactory, aliceWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+
+          await expect(gateway.deployIdentity(aliceWallet.address, 'saltToUse', ethers.utils.randomBytes(65))).to.be.reverted;
+        });
+      });
+
+      describe('when signature is signed by a non authorized signer', () => {
+        it('should revert with UnsignedDeployment', async () => {
+          const { identityFactory, aliceWallet, bobWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+
+          await expect(
+            gateway.deployIdentity(
+              aliceWallet.address,
+              'saltToUse',
+              bobWallet.signMessage(
+                ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'string'], [aliceWallet.address, 'saltToUse'])),
+              ),
+            ),
+          ).to.be.revertedWithCustomError(gateway, 'UnapprovedSigner');
+        });
+      });
+
+      describe('when signature is correct and signed by an authorized signer', () => {
+        it('should deploy the identity', async () => {
+          const { identityFactory, aliceWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+          await identityFactory.transferOwnership(gateway.address);
+
+          const digest =
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                ['string', 'address', 'string'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse'],
+              ),
+          );
+          const signature = await carolWallet.signMessage(
+            ethers.utils.arrayify(
+              digest,
+            ),
+          );
+
+          const tx = await gateway.deployIdentity(
+            aliceWallet.address,
+            'saltToUse',
+            signature,
+          );
+          await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+          await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+          const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+          const identity = await ethers.getContractAt('Identity', identityAddress);
+          expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+        });
+      });
+
+      describe('when signature is correct and signed by an authorized signer, but revoked', () => {
+        it('should revert', async () => {
+          const { identityFactory, aliceWallet, bobWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+          await identityFactory.transferOwnership(gateway.address);
+
+          const digest =
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                ['string', 'address', 'string'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse'],
+              ),
+            );
+          const signature = await carolWallet.signMessage(
+            ethers.utils.arrayify(
+              digest,
+            ),
+          );
+
+          await gateway.revokeSignature(signature);
+
+          await expect(gateway.deployIdentity(
+            aliceWallet.address,
+            'saltToUse',
+            signature,
+          )).to.be.revertedWithCustomError(gateway, 'RevokedSignature');
+        });
+      });
+    });
+  });
+});

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -2,8 +2,9 @@ import {ethers} from "hardhat";
 import {expect} from "chai";
 import {loadFixture} from "@nomicfoundation/hardhat-network-helpers";
 import {deployFactoryFixture} from "../fixtures";
+import {BigNumber} from "ethers";
 
-describe('Gateway', () => {
+describe.only('Gateway', () => {
   describe('constructor', () => {
     describe('when factory address is not specified', () => {
       it('should revert', async () => {
@@ -16,24 +17,25 @@ describe('Gateway', () => {
     describe('when Gateway requires signature', () => {
       describe('when signature is not valid', () => {
         it('should revert with UnsignedDeployment', async () => {
-          const { identityFactory, aliceWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
           const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
 
-          await expect(gateway.deployIdentity(aliceWallet.address, 'saltToUse', ethers.utils.randomBytes(65))).to.be.reverted;
+          await expect(gateway.deployIdentity(aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60), ethers.utils.randomBytes(65))).to.be.reverted;
         });
       });
 
       describe('when signature is signed by a non authorized signer', () => {
         it('should revert with UnsignedDeployment', async () => {
-          const { identityFactory, aliceWallet, bobWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
           const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
 
           await expect(
             gateway.deployIdentity(
               aliceWallet.address,
               'saltToUse',
+              BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
               bobWallet.signMessage(
-                ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'string'], [aliceWallet.address, 'saltToUse'])),
+                ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['string', 'address', 'string', 'uint256'], ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)])),
               ),
             ),
           ).to.be.revertedWithCustomError(gateway, 'UnapprovedSigner');
@@ -42,17 +44,17 @@ describe('Gateway', () => {
 
       describe('when signature is correct and signed by an authorized signer', () => {
         it('should deploy the identity', async () => {
-          const { identityFactory, aliceWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
           const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
           await identityFactory.transferOwnership(gateway.address);
 
           const digest =
             ethers.utils.keccak256(
               ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse'],
+                ['string', 'address', 'string', 'uint256'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
               ),
-          );
+            );
           const signature = await carolWallet.signMessage(
             ethers.utils.arrayify(
               digest,
@@ -62,6 +64,7 @@ describe('Gateway', () => {
           const tx = await gateway.deployIdentity(
             aliceWallet.address,
             'saltToUse',
+            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
             signature,
           );
           await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
@@ -74,15 +77,15 @@ describe('Gateway', () => {
 
       describe('when signature is correct and signed by an authorized signer, but revoked', () => {
         it('should revert', async () => {
-          const { identityFactory, aliceWallet, bobWallet, carolWallet } = await loadFixture(deployFactoryFixture);
+          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
           const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
           await identityFactory.transferOwnership(gateway.address);
 
           const digest =
             ethers.utils.keccak256(
               ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse'],
+                ['string', 'address', 'string', 'uint256'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
               ),
             );
           const signature = await carolWallet.signMessage(
@@ -96,8 +99,39 @@ describe('Gateway', () => {
           await expect(gateway.deployIdentity(
             aliceWallet.address,
             'saltToUse',
+            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
             signature,
           )).to.be.revertedWithCustomError(gateway, 'RevokedSignature');
+        });
+      });
+
+      describe('when signature is correct and signed by an authorized signer, but has expired', () => {
+        it('should revert', async () => {
+          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+          await identityFactory.transferOwnership(gateway.address);
+
+          const digest =
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                ['string', 'address', 'string', 'uint256'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60)],
+              ),
+            );
+          const signature = await carolWallet.signMessage(
+            ethers.utils.arrayify(
+              digest,
+            ),
+          );
+
+          await gateway.revokeSignature(signature);
+
+          await expect(gateway.deployIdentity(
+            aliceWallet.address,
+            'saltToUse',
+            BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60),
+            signature,
+          )).to.be.revertedWithCustomError(gateway, 'ExpiredSignature');
         });
       });
     });

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -235,7 +235,13 @@ describe('Gateway', () => {
   describe('.transferFactoryOwnership', () => {
     describe('when called by the owner', () => {
       it('should transfer ownership of the factory to the specified address', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -246,7 +252,13 @@ describe('Gateway', () => {
 
     describe('when not called by the owner', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -258,7 +270,13 @@ describe('Gateway', () => {
   describe('.revokeSignature', () => {
     describe('when calling not as owner', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -281,7 +299,13 @@ describe('Gateway', () => {
 
     describe('when signature was already revoked', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -308,7 +332,13 @@ describe('Gateway', () => {
   describe('.approveSignature', () => {
     describe('when calling not as owner', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -331,7 +361,13 @@ describe('Gateway', () => {
 
     describe('when signature is not revoked', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -354,7 +390,13 @@ describe('Gateway', () => {
 
     describe('when signature is revoked', () => {
       it('should approve the signature', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -383,7 +425,13 @@ describe('Gateway', () => {
   describe('.approveSigner', () => {
     describe('when signer address is zero', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -393,7 +441,13 @@ describe('Gateway', () => {
 
     describe('when calling not as owner', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -403,7 +457,13 @@ describe('Gateway', () => {
 
     describe('when signer is already approved', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -415,7 +475,13 @@ describe('Gateway', () => {
 
     describe('when signer is not approved', () => {
       it('should approve the signer', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -429,7 +495,13 @@ describe('Gateway', () => {
   describe('.revokeSigner', () => {
     describe('when signer address is zero', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
 
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [aliceWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
@@ -440,7 +512,13 @@ describe('Gateway', () => {
 
     describe('when calling not as owner', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [bobWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
@@ -450,7 +528,13 @@ describe('Gateway', () => {
 
     describe('when signer is not approved', () => {
       it('should revert', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
 
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [aliceWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
@@ -461,7 +545,13 @@ describe('Gateway', () => {
 
     describe('when signer is approved', () => {
       it('should revoke the signer', async () => {
-        const {identityFactory, deployerWallet, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
 
         const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [bobWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
@@ -469,6 +559,64 @@ describe('Gateway', () => {
         const tx = await gateway.revokeSigner(bobWallet.address);
 
         expect(tx).to.emit(gateway, "SignerRevoked").withArgs(bobWallet.address);
+      });
+    });
+  });
+
+  describe('.callFactory', () => {
+    describe('when not calling as the owner', () => {
+      it('should revert', async () => {
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
+
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [aliceWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        await expect(gateway.connect(aliceWallet).callFactory(
+          new ethers.utils.Interface(['function addTokenFactory(address)']).encodeFunctionData('addTokenFactory', [ethers.constants.AddressZero]))
+        ).to.be.revertedWith('Ownable: caller is not the owner');
+      });
+    });
+
+    describe('when calling as the owner with invalid parameters', () => {
+      it('should revert for Factory error', async () => {
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+          carolWallet
+        } = await loadFixture(deployFactoryFixture);
+
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [aliceWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        await expect(gateway.connect(deployerWallet).callFactory(
+          new ethers.utils.Interface(['function addTokenFactory(address)']).encodeFunctionData('addTokenFactory', [ethers.constants.AddressZero]))
+        ).to.be.revertedWith('Gateway: call to factory failed');
+      });
+    });
+
+    describe('when calling as the owner with correct parameters', () => {
+      it('should execute the function call', async () => {
+        const {
+          identityFactory,
+          deployerWallet,
+          aliceWallet,
+          bobWallet,
+        } = await loadFixture(deployFactoryFixture);
+
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [aliceWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        const tx = await gateway.connect(deployerWallet).callFactory(new ethers.utils.Interface(['function addTokenFactory(address)']).encodeFunctionData('addTokenFactory', [bobWallet.address]));
+
+        expect(tx).to.emit(gateway, "TokenFactoryAdded").withArgs(bobWallet.address);
       });
     });
   });

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -4,7 +4,7 @@ import {loadFixture} from "@nomicfoundation/hardhat-network-helpers";
 import {deployFactoryFixture} from "../fixtures";
 import {BigNumber} from "ethers";
 
-describe.only('Gateway', () => {
+describe('Gateway', () => {
   describe('constructor', () => {
     describe('when factory address is not specified', () => {
       it('should revert', async () => {

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -8,184 +8,201 @@ describe.only('Gateway', () => {
   describe('constructor', () => {
     describe('when factory address is not specified', () => {
       it('should revert', async () => {
-        await expect(ethers.deployContract('Gateway', [ethers.constants.AddressZero, false, []])).to.be.reverted;
+        await expect(ethers.deployContract('Gateway', [ethers.constants.AddressZero, []])).to.be.reverted;
       });
     });
   });
 
-  describe('.deployIdentity()', () => {
-    describe('when Gateway requires signature', () => {
-      describe('when signature is not valid', () => {
-        it('should revert with UnsignedDeployment', async () => {
-          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+  describe('.deployIdentityWithSalt()', () => {
+    describe('when signature is not valid', () => {
+      it('should revert with UnsignedDeployment', async () => {
+        const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
 
-          await expect(gateway.deployIdentity(aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60), ethers.utils.randomBytes(65))).to.be.reverted;
-        });
-      });
-
-      describe('when signature is signed by a non authorized signer', () => {
-        it('should revert with UnsignedDeployment', async () => {
-          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-
-          await expect(
-            gateway.deployIdentity(
-              aliceWallet.address,
-              'saltToUse',
-              BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
-              bobWallet.signMessage(
-                ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['string', 'address', 'string', 'uint256'], ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)])),
-              ),
-            ),
-          ).to.be.revertedWithCustomError(gateway, 'UnapprovedSigner');
-        });
-      });
-
-      describe('when signature is correct and signed by an authorized signer', () => {
-        it('should deploy the identity', async () => {
-          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-          await identityFactory.transferOwnership(gateway.address);
-
-          const digest =
-            ethers.utils.keccak256(
-              ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string', 'uint256'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
-              ),
-            );
-          const signature = await carolWallet.signMessage(
-            ethers.utils.arrayify(
-              digest,
-            ),
-          );
-
-          const tx = await gateway.deployIdentity(
-            aliceWallet.address,
-            'saltToUse',
-            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
-            signature,
-          );
-          await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
-          await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
-          const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
-          const identity = await ethers.getContractAt('Identity', identityAddress);
-          expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
-        });
-      });
-
-      describe('when signature is correct with no expiry', () => {
-        it('should deploy the identity', async () => {
-          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-          await identityFactory.transferOwnership(gateway.address);
-
-          const digest =
-            ethers.utils.keccak256(
-              ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string', 'uint256'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', 0],
-              ),
-            );
-          const signature = await carolWallet.signMessage(
-            ethers.utils.arrayify(
-              digest,
-            ),
-          );
-
-          const tx = await gateway.deployIdentity(
-            aliceWallet.address,
-            'saltToUse',
-            0,
-            signature,
-          );
-          await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
-          await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
-          const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
-          const identity = await ethers.getContractAt('Identity', identityAddress);
-          expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
-        });
-      });
-
-      describe('when signature is correct and signed by an authorized signer, but revoked', () => {
-        it('should revert', async () => {
-          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-          await identityFactory.transferOwnership(gateway.address);
-
-          const digest =
-            ethers.utils.keccak256(
-              ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string', 'uint256'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
-              ),
-            );
-          const signature = await carolWallet.signMessage(
-            ethers.utils.arrayify(
-              digest,
-            ),
-          );
-
-          await gateway.revokeSignature(signature);
-
-          await expect(gateway.deployIdentity(
-            aliceWallet.address,
-            'saltToUse',
-            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
-            signature,
-          )).to.be.revertedWithCustomError(gateway, 'RevokedSignature');
-        });
-      });
-
-      describe('when signature is correct and signed by an authorized signer, but has expired', () => {
-        it('should revert', async () => {
-          const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
-          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
-          await identityFactory.transferOwnership(gateway.address);
-
-          const digest =
-            ethers.utils.keccak256(
-              ethers.utils.defaultAbiCoder.encode(
-                ['string', 'address', 'string', 'uint256'],
-                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60)],
-              ),
-            );
-          const signature = await carolWallet.signMessage(
-            ethers.utils.arrayify(
-              digest,
-            ),
-          );
-
-          await gateway.revokeSignature(signature);
-
-          await expect(gateway.deployIdentity(
-            aliceWallet.address,
-            'saltToUse',
-            BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60),
-            signature,
-          )).to.be.revertedWithCustomError(gateway, 'ExpiredSignature');
-        });
+        await expect(gateway.deployIdentityWithSalt(aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60), ethers.utils.randomBytes(65))).to.be.reverted;
       });
     });
 
-    describe('when gateway does not require a signature', () => {
-      it('should deploy an identity when requested', async () => {
-        const {identityFactory, aliceWallet} = await loadFixture(deployFactoryFixture);
-        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, false, []]);
+    describe('when signature is signed by a non authorized signer', () => {
+      it('should revert with UnsignedDeployment', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+
+        await expect(
+          gateway.deployIdentityWithSalt(
+            aliceWallet.address,
+            'saltToUse',
+            BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
+            bobWallet.signMessage(
+              ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['string', 'address', 'string', 'uint256'], ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)])),
+            ),
+          ),
+        ).to.be.revertedWithCustomError(gateway, 'UnapprovedSigner');
+      });
+    });
+
+    describe('when signature is correct and signed by an authorized signer', () => {
+      it('should deploy the identity', async () => {
+        const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
         await identityFactory.transferOwnership(gateway.address);
 
-        const tx = await gateway.deployIdentity(
+        const digest =
+          ethers.utils.keccak256(
+            ethers.utils.defaultAbiCoder.encode(
+              ['string', 'address', 'string', 'uint256'],
+              ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
+            ),
+          );
+        const signature = await carolWallet.signMessage(
+          ethers.utils.arrayify(
+            digest,
+          ),
+        );
+
+        const tx = await gateway.deployIdentityWithSalt(
           aliceWallet.address,
           'saltToUse',
           BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
-          ethers.utils.randomBytes(65),
+          signature,
         );
         await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
         await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
         const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
         const identity = await ethers.getContractAt('Identity', identityAddress);
         expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+      });
+    });
+
+    describe('when signature is correct with no expiry', () => {
+      it('should deploy the identity', async () => {
+        const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        const digest =
+          ethers.utils.keccak256(
+            ethers.utils.defaultAbiCoder.encode(
+              ['string', 'address', 'string', 'uint256'],
+              ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', 0],
+            ),
+          );
+        const signature = await carolWallet.signMessage(
+          ethers.utils.arrayify(
+            digest,
+          ),
+        );
+
+        const tx = await gateway.deployIdentityWithSalt(
+          aliceWallet.address,
+          'saltToUse',
+          0,
+          signature,
+        );
+        await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+        await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+        const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+        const identity = await ethers.getContractAt('Identity', identityAddress);
+        expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+      });
+    });
+
+    describe('when signature is correct and signed by an authorized signer, but revoked', () => {
+      it('should revert', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        const digest =
+          ethers.utils.keccak256(
+            ethers.utils.defaultAbiCoder.encode(
+              ['string', 'address', 'string', 'uint256'],
+              ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60)],
+            ),
+          );
+        const signature = await carolWallet.signMessage(
+          ethers.utils.arrayify(
+            digest,
+          ),
+        );
+
+        await gateway.revokeSignature(signature);
+
+        await expect(gateway.deployIdentityWithSalt(
+          aliceWallet.address,
+          'saltToUse',
+          BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
+          signature,
+        )).to.be.revertedWithCustomError(gateway, 'RevokedSignature');
+      });
+    });
+
+    describe('when signature is correct and signed by an authorized signer, but has expired', () => {
+      it('should revert', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        const digest =
+          ethers.utils.keccak256(
+            ethers.utils.defaultAbiCoder.encode(
+              ['string', 'address', 'string', 'uint256'],
+              ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60)],
+            ),
+          );
+        const signature = await carolWallet.signMessage(
+          ethers.utils.arrayify(
+            digest,
+          ),
+        );
+
+        await gateway.revokeSignature(signature);
+
+        await expect(gateway.deployIdentityWithSalt(
+          aliceWallet.address,
+          'saltToUse',
+          BigNumber.from(new Date().getTime()).div(1000).sub(2 * 24 * 60 * 60),
+          signature,
+        )).to.be.revertedWithCustomError(gateway, 'ExpiredSignature');
+      });
+    });
+  });
+
+  describe('deployIdentityForWallet', () => {
+    describe('when sender is not the desired identity owner', () => {
+      it('should revert', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+        await expect(gateway.deployIdentityForWallet(aliceWallet.address)).to.revertedWithCustomError(gateway, 'UnapprovedSigner');
+      });
+    });
+
+    describe('when an identity was not yet deployed for this walet', () => {
+      it('should deploy the identity', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+        const tx = await gateway.connect(aliceWallet).deployIdentityForWallet(aliceWallet.address);
+
+        await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+        await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+        const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+        const identity = await ethers.getContractAt('Identity', identityAddress);
+
+        expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+      });
+    });
+
+    describe('when an identity was already deployed for this wallet as salt with the factory', () => {
+      it('should revert because factory reverts', async () => {
+        const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, [carolWallet.address]]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        await gateway.connect(aliceWallet).deployIdentityForWallet(aliceWallet.address);
+
+        await expect(gateway.connect(aliceWallet).deployIdentityForWallet(aliceWallet.address)).to.be.revertedWith('salt already taken');
       });
     });
   });

--- a/test/gateway/gateway.test.ts
+++ b/test/gateway/gateway.test.ts
@@ -75,6 +75,39 @@ describe.only('Gateway', () => {
         });
       });
 
+      describe('when signature is correct with no expiry', () => {
+        it('should deploy the identity', async () => {
+          const {identityFactory, aliceWallet, carolWallet} = await loadFixture(deployFactoryFixture);
+          const gateway = await ethers.deployContract('Gateway', [identityFactory.address, true, [carolWallet.address]]);
+          await identityFactory.transferOwnership(gateway.address);
+
+          const digest =
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                ['string', 'address', 'string', 'uint256'],
+                ['Authorize ONCHAINID deployment', aliceWallet.address, 'saltToUse', 0],
+              ),
+            );
+          const signature = await carolWallet.signMessage(
+            ethers.utils.arrayify(
+              digest,
+            ),
+          );
+
+          const tx = await gateway.deployIdentity(
+            aliceWallet.address,
+            'saltToUse',
+            0,
+            signature,
+          );
+          await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+          await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+          const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+          const identity = await ethers.getContractAt('Identity', identityAddress);
+          expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
+        });
+      });
+
       describe('when signature is correct and signed by an authorized signer, but revoked', () => {
         it('should revert', async () => {
           const {identityFactory, aliceWallet, bobWallet, carolWallet} = await loadFixture(deployFactoryFixture);
@@ -133,6 +166,26 @@ describe.only('Gateway', () => {
             signature,
           )).to.be.revertedWithCustomError(gateway, 'ExpiredSignature');
         });
+      });
+    });
+
+    describe('when gateway does not require a signature', () => {
+      it('should deploy an identity when requested', async () => {
+        const {identityFactory, aliceWallet} = await loadFixture(deployFactoryFixture);
+        const gateway = await ethers.deployContract('Gateway', [identityFactory.address, false, []]);
+        await identityFactory.transferOwnership(gateway.address);
+
+        const tx = await gateway.deployIdentity(
+          aliceWallet.address,
+          'saltToUse',
+          BigNumber.from(new Date().getTime()).div(1000).add(365 * 24 * 60 * 60),
+          ethers.utils.randomBytes(65),
+        );
+        await expect(tx).to.emit(identityFactory, "WalletLinked").withArgs(aliceWallet.address, await identityFactory.getIdentity(aliceWallet.address));
+        await expect(tx).to.emit(identityFactory, "Deployed").withArgs(await identityFactory.getIdentity(aliceWallet.address));
+        const identityAddress = await identityFactory.getIdentity(aliceWallet.address);
+        const identity = await ethers.getContractAt('Identity', identityAddress);
+        expect(await identity.keyHasPurpose(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address'], [aliceWallet.address])), 1)).to.be.true;
       });
     });
   });

--- a/test/verifiers/verifier-user.test.ts
+++ b/test/verifiers/verifier-user.test.ts
@@ -1,0 +1,106 @@
+import {ethers} from "hardhat";
+import {expect} from "chai";
+
+describe.only('VerifierUser', () => {
+  describe('when calling a verified function not as an identity', () => {
+    it('should revert', async () => {
+      const verifierUser = await ethers.deployContract('VerifierUser', []);
+
+      await verifierUser.addClaimTopic(666);
+
+      await expect(verifierUser.doSomething()).to.be.reverted;
+    });
+  });
+
+  describe('when identity is verified', () => {
+    it('should return', async () => {
+      const [deployer, aliceWallet, claimIssuerWallet] = await ethers.getSigners();
+      const claimIssuer = await ethers.deployContract('ClaimIssuer', [claimIssuerWallet.address]);
+      const aliceIdentity = await ethers.deployContract('Identity', [aliceWallet.address, false]);
+      const verifierUser = await ethers.deployContract('VerifierUser', []);
+
+      await verifierUser.addClaimTopic(666);
+      await verifierUser.addTrustedIssuer(claimIssuer.address, [666]);
+
+      const aliceClaim666 = {
+        id: '',
+        identity: aliceIdentity.address,
+        issuer: claimIssuer.address,
+        topic: 666,
+        scheme: 1,
+        data: '0x0042',
+        signature: '',
+        uri: 'https://example.com',
+      };
+      aliceClaim666.signature = await claimIssuerWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim666.identity, aliceClaim666.topic, aliceClaim666.data]))));
+      await aliceIdentity.connect(aliceWallet).addClaim(
+        aliceClaim666.topic,
+        aliceClaim666.scheme,
+        aliceClaim666.issuer,
+        aliceClaim666.signature,
+        aliceClaim666.data,
+        aliceClaim666.uri,
+      );
+
+      const action = {
+        to: verifierUser.address,
+        value: 0,
+        data: new ethers.utils.Interface(['function doSomething()']).encodeFunctionData('doSomething'),
+      };
+
+      const tx = await aliceIdentity.connect(aliceWallet).execute(
+        action.to,
+        action.value,
+        action.data,
+      );
+      expect(tx).to.emit(aliceIdentity, 'Executed');
+    });
+  });
+
+  describe('when identity is not verified', () => {
+    it('should revert', async () => {
+      const [deployer, aliceWallet, claimIssuerWallet] = await ethers.getSigners();
+      const claimIssuer = await ethers.deployContract('ClaimIssuer', [claimIssuerWallet.address]);
+      const aliceIdentity = await ethers.deployContract('Identity', [aliceWallet.address, false]);
+      const verifierUser = await ethers.deployContract('VerifierUser', []);
+
+      await verifierUser.addClaimTopic(666);
+      await verifierUser.addTrustedIssuer(claimIssuer.address, [666]);
+
+      const aliceClaim666 = {
+        id: '',
+        identity: aliceIdentity.address,
+        issuer: claimIssuer.address,
+        topic: 666,
+        scheme: 1,
+        data: '0x0042',
+        signature: '',
+        uri: 'https://example.com',
+      };
+      aliceClaim666.signature = await claimIssuerWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim666.identity, aliceClaim666.topic, aliceClaim666.data]))));
+      await aliceIdentity.connect(aliceWallet).addClaim(
+        aliceClaim666.topic,
+        aliceClaim666.scheme,
+        aliceClaim666.issuer,
+        aliceClaim666.signature,
+        aliceClaim666.data,
+        aliceClaim666.uri,
+      );
+
+      await claimIssuer.connect(claimIssuerWallet).revokeClaimBySignature(aliceClaim666.signature);
+
+      const action = {
+        to: verifierUser.address,
+        value: 0,
+        data: new ethers.utils.Interface(['function doSomething()']).encodeFunctionData('doSomething'),
+      };
+
+      const tx = await aliceIdentity.connect(aliceWallet).execute(
+        action.to,
+        action.value,
+        action.data,
+      );
+      expect(tx).to.emit(aliceIdentity, 'ExecutionFailed');
+    });
+  });
+});

--- a/test/verifiers/verifier-user.test.ts
+++ b/test/verifiers/verifier-user.test.ts
@@ -1,7 +1,7 @@
 import {ethers} from "hardhat";
 import {expect} from "chai";
 
-describe.only('VerifierUser', () => {
+describe('VerifierUser', () => {
   describe('when calling a verified function not as an identity', () => {
     it('should revert', async () => {
       const verifierUser = await ethers.deployContract('VerifierUser', []);

--- a/test/verifiers/verifier.test.ts
+++ b/test/verifiers/verifier.test.ts
@@ -1,0 +1,523 @@
+import {ethers} from "hardhat";
+import {expect} from "chai";
+
+
+describe('Verifier', () => {
+  describe('.verify()', () => {
+    describe('when the Verifier does expect claim topics', () => {
+      it('should return true', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+
+        await expect(verifier.verify(aliceWallet.address)).to.eventually.be.true;
+      });
+    });
+
+    describe('when the Verifier expect one claim topic but has no trusted issuers', () => {
+      it('should return false', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        await verifier.addClaimTopic(ethers.utils.formatBytes32String('SOME_TOPIC'));
+
+        await expect(verifier.verify(aliceWallet.address)).to.eventually.be.false;
+      });
+    });
+
+    describe('when the Verifier expect one claim topic and a trusted issuer for another topic', () => {
+      it('should return false', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        await verifier.addClaimTopic(ethers.utils.formatBytes32String('SOME_TOPIC'));
+        await verifier.addTrustedIssuer(deployer.address, [ethers.utils.formatBytes32String('SOME_OTHER_TOPIC')]);
+
+        await expect(verifier.verify(aliceWallet.address)).to.eventually.be.false;
+      });
+    });
+
+    describe('when the Verifier expect one claim topic and a trusted issuer for the topic', () => {
+      describe('when the identity does not have the claim', () => {
+        it('should return false', async () => {
+          const [deployer, aliceWallet, claimIssuerWallet] = await ethers.getSigners();
+          const verifier = await ethers.deployContract('Verifier');
+          const claimIssuer = await ethers.deployContract('ClaimIssuer', [claimIssuerWallet.address]);
+          const aliceIdentity = await ethers.deployContract('Identity', [aliceWallet.address, false]);
+          await verifier.addClaimTopic(ethers.utils.formatBytes32String('SOME_TOPIC'));
+          await verifier.addTrustedIssuer(claimIssuer.address, [ethers.utils.formatBytes32String('SOME_TOPIC')]);
+
+          await expect(verifier.verify(aliceIdentity.address)).to.eventually.be.false;
+        });
+      });
+
+      describe('when the identity does not have a valid expected claim', () => {
+        it('should return false', async () => {
+          const [deployer, aliceWallet, claimIssuerWallet] = await ethers.getSigners();
+          const verifier = await ethers.deployContract('Verifier');
+          const claimIssuer = await ethers.deployContract('ClaimIssuer', [claimIssuerWallet.address]);
+          const aliceIdentity = await ethers.deployContract('Identity', [aliceWallet.address, false]);
+
+          await verifier.addClaimTopic(666);
+          await verifier.addTrustedIssuer(claimIssuer.address, [666]);
+
+          const aliceClaim666 = {
+            id: '',
+            identity: aliceIdentity.address,
+            issuer: claimIssuer.address,
+            topic: 666,
+            scheme: 1,
+            data: '0x0042',
+            signature: '',
+            uri: 'https://example.com',
+          };
+          aliceClaim666.signature = await claimIssuerWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim666.identity, aliceClaim666.topic, aliceClaim666.data]))));
+          await aliceIdentity.connect(aliceWallet).addClaim(
+            aliceClaim666.topic,
+            aliceClaim666.scheme,
+            aliceClaim666.issuer,
+            aliceClaim666.signature,
+            aliceClaim666.data,
+            aliceClaim666.uri,
+          );
+          await claimIssuer.connect(claimIssuerWallet).revokeClaimBySignature(
+            aliceClaim666.signature,
+          );
+
+          await expect(verifier.verify(aliceIdentity.address)).to.eventually.be.false;
+        });
+      });
+
+      describe('when the identity has the valid expected claim', () => {
+        it('should return true', async () => {
+          const [deployer, aliceWallet, claimIssuerWallet] = await ethers.getSigners();
+          const verifier = await ethers.deployContract('Verifier');
+          const claimIssuer = await ethers.deployContract('ClaimIssuer', [claimIssuerWallet.address]);
+          const aliceIdentity = await ethers.deployContract('Identity', [aliceWallet.address, false]);
+
+          await verifier.addClaimTopic(666);
+          await verifier.addTrustedIssuer(claimIssuer.address, [666]);
+
+          const aliceClaim666 = {
+            id: '',
+            identity: aliceIdentity.address,
+            issuer: claimIssuer.address,
+            topic: 666,
+            scheme: 1,
+            data: '0x0042',
+            signature: '',
+            uri: 'https://example.com',
+          };
+          aliceClaim666.signature = await claimIssuerWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim666.identity, aliceClaim666.topic, aliceClaim666.data]))));
+          await aliceIdentity.connect(aliceWallet).addClaim(
+            aliceClaim666.topic,
+            aliceClaim666.scheme,
+            aliceClaim666.issuer,
+            aliceClaim666.signature,
+            aliceClaim666.data,
+            aliceClaim666.uri,
+          );
+
+          await expect(verifier.verify(aliceIdentity.address)).to.eventually.be.true;
+        });
+      });
+    });
+
+    describe('when the Verifier expect multiple claim topics and allow multiple trusted issuers', () => {
+      describe('when identity is compliant', () => {
+        it('should return true', async () => {
+          const [deployer, aliceWallet, claimIssuerAWallet, claimIssuerBWallet, claimIssuerCWallet] = await ethers.getSigners();
+          const verifier = await ethers.deployContract('Verifier');
+          const claimIssuerA = await ethers.deployContract('ClaimIssuer', [claimIssuerAWallet.address]);
+          const claimIssuerB = await ethers.deployContract('ClaimIssuer', [claimIssuerBWallet.address]);
+          const claimIssuerC = await ethers.deployContract('ClaimIssuer', [claimIssuerCWallet.address]);
+          const aliceIdentity = await ethers.deployContract('Identity', [aliceWallet.address, false]);
+
+          await verifier.addClaimTopic(666);
+          await verifier.addTrustedIssuer(claimIssuerA.address, [666]);
+          await verifier.addClaimTopic(42);
+          await verifier.addTrustedIssuer(claimIssuerB.address, [42, 666]);
+
+          const aliceClaim666C = {
+            id: '',
+            identity: aliceIdentity.address,
+            issuer: claimIssuerC.address,
+            topic: 666,
+            scheme: 1,
+            data: '0x0042',
+            signature: '',
+            uri: 'https://example.com',
+          };
+          aliceClaim666C.signature = await claimIssuerCWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim666C.identity, aliceClaim666C.topic, aliceClaim666C.data]))));
+          await aliceIdentity.connect(aliceWallet).addClaim(
+            aliceClaim666C.topic,
+            aliceClaim666C.scheme,
+            aliceClaim666C.issuer,
+            aliceClaim666C.signature,
+            aliceClaim666C.data,
+            aliceClaim666C.uri,
+          );
+
+          const aliceClaim666 = {
+            id: '',
+            identity: aliceIdentity.address,
+            issuer: claimIssuerA.address,
+            topic: 666,
+            scheme: 1,
+            data: '0x0042',
+            signature: '',
+            uri: 'https://example.com',
+          };
+          aliceClaim666.signature = await claimIssuerAWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim666.identity, aliceClaim666.topic, aliceClaim666.data]))));
+          await aliceIdentity.connect(aliceWallet).addClaim(
+            aliceClaim666.topic,
+            aliceClaim666.scheme,
+            aliceClaim666.issuer,
+            aliceClaim666.signature,
+            aliceClaim666.data,
+            aliceClaim666.uri,
+          );
+
+          const aliceClaim666B = {
+            id: '',
+            identity: aliceIdentity.address,
+            issuer: claimIssuerB.address,
+            topic: 666,
+            scheme: 1,
+            data: '0x0066',
+            signature: '',
+            uri: 'https://example.com/B/666',
+          };
+          aliceClaim666B.signature = await claimIssuerBWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim666B.identity, aliceClaim666B.topic, aliceClaim666B.data]))));
+          await aliceIdentity.connect(aliceWallet).addClaim(
+            aliceClaim666B.topic,
+            aliceClaim666B.scheme,
+            aliceClaim666B.issuer,
+            aliceClaim666B.signature,
+            aliceClaim666B.data,
+            aliceClaim666B.uri,
+          );
+
+          const aliceClaim42 = {
+            id: '',
+            identity: aliceIdentity.address,
+            issuer: claimIssuerB.address,
+            topic: 42,
+            scheme: 1,
+            data: '0x0010',
+            signature: '',
+            uri: 'https://example.com/42',
+          };
+          aliceClaim42.signature = await claimIssuerBWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim42.identity, aliceClaim42.topic, aliceClaim42.data]))));
+          await aliceIdentity.connect(aliceWallet).addClaim(
+            aliceClaim42.topic,
+            aliceClaim42.scheme,
+            aliceClaim42.issuer,
+            aliceClaim42.signature,
+            aliceClaim42.data,
+            aliceClaim42.uri,
+          );
+
+          await claimIssuerB.connect(claimIssuerBWallet).revokeClaimBySignature(aliceClaim666B.signature);
+
+          await expect(verifier.verify(aliceIdentity.address)).to.eventually.be.true;
+        });
+      });
+
+      describe('when identity is not compliant', () => {
+        it('should return false', async () => {
+          const [deployer, aliceWallet, claimIssuerAWallet, claimIssuerBWallet] = await ethers.getSigners();
+          const verifier = await ethers.deployContract('Verifier');
+          const claimIssuerA = await ethers.deployContract('ClaimIssuer', [claimIssuerAWallet.address]);
+          const claimIssuerB = await ethers.deployContract('ClaimIssuer', [claimIssuerBWallet.address]);
+          const aliceIdentity = await ethers.deployContract('Identity', [aliceWallet.address, false]);
+
+          await verifier.addClaimTopic(666);
+          await verifier.addTrustedIssuer(claimIssuerA.address, [666]);
+          await verifier.addClaimTopic(42);
+          await verifier.addTrustedIssuer(claimIssuerB.address, [42, 666]);
+
+          const aliceClaim666 = {
+            id: '',
+            identity: aliceIdentity.address,
+            issuer: claimIssuerA.address,
+            topic: 666,
+            scheme: 1,
+            data: '0x0042',
+            signature: '',
+            uri: 'https://example.com',
+          };
+          aliceClaim666.signature = await claimIssuerAWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim666.identity, aliceClaim666.topic, aliceClaim666.data]))));
+          await aliceIdentity.connect(aliceWallet).addClaim(
+            aliceClaim666.topic,
+            aliceClaim666.scheme,
+            aliceClaim666.issuer,
+            aliceClaim666.signature,
+            aliceClaim666.data,
+            aliceClaim666.uri,
+          );
+
+          const aliceClaim666B = {
+            id: '',
+            identity: aliceIdentity.address,
+            issuer: claimIssuerB.address,
+            topic: 666,
+            scheme: 1,
+            data: '0x0066',
+            signature: '',
+            uri: 'https://example.com/B/666',
+          };
+          aliceClaim666B.signature = await claimIssuerBWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim666B.identity, aliceClaim666B.topic, aliceClaim666B.data]))));
+          await aliceIdentity.connect(aliceWallet).addClaim(
+            aliceClaim666B.topic,
+            aliceClaim666B.scheme,
+            aliceClaim666B.issuer,
+            aliceClaim666B.signature,
+            aliceClaim666B.data,
+            aliceClaim666B.uri,
+          );
+
+          const aliceClaim42 = {
+            id: '',
+            identity: aliceIdentity.address,
+            issuer: claimIssuerB.address,
+            topic: 42,
+            scheme: 1,
+            data: '0x0010',
+            signature: '',
+            uri: 'https://example.com/42',
+          };
+          aliceClaim42.signature = await claimIssuerBWallet.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['address', 'uint256', 'bytes'], [aliceClaim42.identity, aliceClaim42.topic, aliceClaim42.data]))));
+          await aliceIdentity.connect(aliceWallet).addClaim(
+            aliceClaim42.topic,
+            aliceClaim42.scheme,
+            aliceClaim42.issuer,
+            aliceClaim42.signature,
+            aliceClaim42.data,
+            aliceClaim42.uri,
+          );
+
+          await claimIssuerB.connect(claimIssuerBWallet).revokeClaimBySignature(aliceClaim42.signature);
+
+          await expect(verifier.verify(aliceIdentity.address)).to.eventually.be.false;
+        });
+      });
+    });
+  });
+
+  describe('.removeClaimTopic', () => {
+    describe('when not called by the owner', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+
+        await expect(verifier.connect(aliceWallet).removeClaimTopic(2)).to.be.revertedWith('Ownable: caller is not the owner');
+      });
+    });
+
+    describe('when called by the owner', () => {
+      it('should remove the claim topic', async () => {
+        const [deployer] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        await verifier.addClaimTopic(1);
+        await verifier.addClaimTopic(2);
+        await verifier.addClaimTopic(3);
+
+        const tx = await verifier.removeClaimTopic(2);
+        await expect(tx).to.emit(verifier, 'ClaimTopicRemoved').withArgs(2);
+        expect(await verifier.isClaimTopicRequired(1)).to.be.true;
+        expect(await verifier.isClaimTopicRequired(2)).to.be.false;
+        expect(await verifier.isClaimTopicRequired(3)).to.be.true;
+      });
+    });
+  });
+
+  describe('.removeTrustedIssuer', () => {
+    describe('when not called by the owner', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+
+        await expect(verifier.connect(aliceWallet).removeTrustedIssuer(claimIssuer.address)).to.be.revertedWith('Ownable: caller is not the owner');
+      });
+    });
+
+    describe('when called by the owner', () => {
+      it('should remove the trusted issuer', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+        const claimIssuerB = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+        await verifier.addTrustedIssuer(claimIssuer.address, [1]);
+        await verifier.addTrustedIssuer(claimIssuerB.address, [2]);
+
+        const tx = await verifier.removeTrustedIssuer(claimIssuer.address);
+        await expect(tx).to.emit(verifier, 'TrustedIssuerRemoved').withArgs(claimIssuer.address);
+        expect(await verifier.isTrustedIssuer(claimIssuer.address)).to.be.false;
+        expect(await verifier.getTrustedIssuers()).to.be.deep.equal([claimIssuerB.address]);
+      });
+    });
+
+    describe('when issuer address is zero', () => {
+      it('should revert', async () => {
+        const [deployer] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+
+        await expect(verifier.removeTrustedIssuer(ethers.constants.AddressZero)).to.be.revertedWith('invalid argument - zero address');
+      });
+    });
+
+    describe('when issuer is not trusted', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+
+        await expect(verifier.removeTrustedIssuer(claimIssuer.address)).to.be.revertedWith('NOT a trusted issuer');
+      });
+    });
+  });
+
+  describe('.addTrustedIssuer', () => {
+    describe('when not called by the owner', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+
+        await expect(verifier.connect(aliceWallet).addTrustedIssuer(claimIssuer.address, [1])).to.be.revertedWith('Ownable: caller is not the owner');
+      });
+    });
+
+    describe('when issuer address is the zero', () => {
+      it('should revert', async () => {
+        const [deployer] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+
+        await expect(verifier.addTrustedIssuer(ethers.constants.AddressZero, [1])).to.be.revertedWith('invalid argument - zero address');
+      });
+    });
+
+    describe('when issuer is already trusted', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+        await verifier.addTrustedIssuer(claimIssuer.address, [1]);
+
+        await expect(verifier.addTrustedIssuer(claimIssuer.address, [2])).to.be.revertedWith('trusted Issuer already exists');
+      });
+    });
+
+    describe('when claim topics array is empty', () => {
+      it('should revert', async () => {
+        const [deployer] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+
+        await expect(verifier.addTrustedIssuer(deployer.address, [])).to.be.revertedWith('trusted claim topics cannot be empty');
+      });
+    });
+
+    describe('when claim topics array contains more than 15 topics', () => {
+      it('should revert', async () => {
+        const [deployer] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+
+        await expect(verifier.addTrustedIssuer(deployer.address, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16])).to.be.revertedWith('cannot have more than 15 claim topics');
+      });
+    });
+
+    describe('when adding a 51th trusted issuer', () => {
+      it('should revert', async () => {
+        const [deployer] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        for (let i = 0; i < 50; i++) {
+          const claimIssuer = await ethers.deployContract('ClaimIssuer', [deployer.address]);
+          await verifier.addTrustedIssuer(claimIssuer.address, [1]);
+        }
+
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [deployer.address]);
+        await expect(verifier.addTrustedIssuer(claimIssuer.address, [1])).to.be.revertedWith('cannot have more than 50 trusted issuers');
+      });
+    });
+  });
+
+  describe('.updateIssuerClaimTopics', () => {
+    describe('when not called by the owner', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+
+        await expect(verifier.connect(aliceWallet).updateIssuerClaimTopics(claimIssuer.address, [1])).to.be.revertedWith('Ownable: caller is not the owner');
+      });
+    });
+
+    describe('when called by the owner', () => {
+      it('should update the issuer claim topics', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+        await verifier.addTrustedIssuer(claimIssuer.address, [1]);
+
+        const tx = await verifier.updateIssuerClaimTopics(claimIssuer.address, [2, 3]);
+        await expect(tx).to.emit(verifier, 'ClaimTopicsUpdated').withArgs(claimIssuer.address, [2, 3]);
+        expect(await verifier.isTrustedIssuer(claimIssuer.address)).to.be.true;
+        expect(await verifier.getTrustedIssuersForClaimTopic(1)).to.be.empty;
+        expect(await verifier.getTrustedIssuerClaimTopics(claimIssuer.address)).to.be.deep.equal([2, 3]);
+        expect(await verifier.hasClaimTopic(claimIssuer.address, 2)).to.be.true;
+        expect(await verifier.hasClaimTopic(claimIssuer.address, 1)).to.be.false;
+      });
+    });
+
+    describe('when issuer address is the zero address', () => {
+      it('should revert', async () => {
+        const verifier = await ethers.deployContract('Verifier');
+
+        await expect(verifier.updateIssuerClaimTopics(ethers.constants.AddressZero, [1])).to.be.revertedWith('invalid argument - zero address');
+      });
+    });
+
+    describe('when issuer is not trusted', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+
+        await expect(verifier.updateIssuerClaimTopics(claimIssuer.address, [1])).to.be.revertedWith('NOT a trusted issuer');
+      });
+    });
+
+    describe('when list of topics contains more than 15 topics', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+        await verifier.addTrustedIssuer(claimIssuer.address, [1]);
+
+        await expect(verifier.updateIssuerClaimTopics(claimIssuer.address, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])).to.be.revertedWith('cannot have more than 15 claim topics');
+      });
+    });
+
+    describe('when list of topics is empty', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+        await verifier.addTrustedIssuer(claimIssuer.address, [1]);
+
+        await expect(verifier.updateIssuerClaimTopics(claimIssuer.address, [])).to.be.revertedWith('claim topics cannot be empty');
+      });
+    });
+  });
+
+  describe('.getTrustedIssuerClaimTopic', () => {
+    describe('when issuer is not trusted', () => {
+      it('should revert', async () => {
+        const [deployer, aliceWallet] = await ethers.getSigners();
+        const verifier = await ethers.deployContract('Verifier');
+        const claimIssuer = await ethers.deployContract('ClaimIssuer', [aliceWallet.address]);
+
+        await expect(verifier.getTrustedIssuerClaimTopics(claimIssuer.address)).to.be.revertedWith('trusted Issuer doesn\'t exist');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add a Verifier contract to be extended by contract that need to verify compliance of identities.

As much as possible I followed the interface used by the TREX Identity Registry to maintain compatibility with SDKs.

See docs in https://github.com/onchain-id/documentation/pull/59