### PR TITLE
:bookmark: (v2.2.1) update version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1]
+
+### Changed
+- Replaced the storage slot used for ImplementationAuthority on the proxies, to avoid conflict with ERC-1822 on
+  block explorers. By using the same storage slot, the explorers were identifying this proxy as an ERC-1822, while
+  it's a different implementation here, the storage slot is not used to store the address of the implementation but
+  the address to ImplementationAuthority contract that references the implementation
+
 ## [2.2.0]
 
 ### Added

--- a/contracts/proxy/IdentityProxy.sol
+++ b/contracts/proxy/IdentityProxy.sol
@@ -19,7 +19,7 @@ contract IdentityProxy {
 
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            sstore(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7, _implementationAuthority)
+            sstore(0x821f3e4d3d679f19eacc940c87acf846ea6eae24a63058ea750304437a62aafc, _implementationAuthority)
         }
 
         address logic = IImplementationAuthority(_implementationAuthority).getImplementation();
@@ -59,7 +59,7 @@ contract IdentityProxy {
         address implemAuth;
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            implemAuth := sload(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7)
+            implemAuth := sload(0x821f3e4d3d679f19eacc940c87acf846ea6eae24a63058ea750304437a62aafc)
         }
         return implemAuth;
     }

--- a/contracts/version/Version.sol
+++ b/contracts/version/Version.sol
@@ -11,6 +11,6 @@ contract Version {
      */
     function version() external pure returns (string memory) {
         // version 2.2.0
-        return "2.2.0";
+        return "2.2.1";
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onchain-id/solidity",
-      "version": "2.0.1",
+      "version": "2.2.1",
       "license": "ISC",
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onchain-id/solidity",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "EVM solidity smart contracts for Blockchain OnchainID identities.",
   "files": [
     "artifacts",

--- a/test/identities/init.test.ts
+++ b/test/identities/init.test.ts
@@ -36,6 +36,6 @@ describe('Identity', () => {
   it('should return the version of the implementation', async () => {
     const {identityImplementation} = await loadFixture(deployIdentityFixture);
 
-    expect(await identityImplementation.version()).to.equal('2.2.0');
+    expect(await identityImplementation.version()).to.equal('2.2.1');
   });
 });


### PR DESCRIPTION
## [2.2.1]

### Changed
- Replaced the storage slot used for ImplementationAuthority on the proxies, to avoid conflict with ERC-1822 on
  block explorers. By using the same storage slot, the explorers were identifying this proxy as an ERC-1822, while
  it's a different implementation here, the storage slot is not used to store the address of the implementation but
  the address to ImplementationAuthority contract that references the implementation