### PR TITLE
♻️ Use OZ for beacon proxy

### DIFF
--- a/contracts/proxy/IdentityProxy.sol
+++ b/contracts/proxy/IdentityProxy.sol
@@ -1,67 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
-
 pragma solidity 0.8.27;
 
-import { IImplementationAuthority } from "../interface/IImplementationAuthority.sol";
-import { Errors } from "../libraries/Errors.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 
-contract IdentityProxy {
+contract IdentityProxy is BeaconProxy {
 
-    /**
-     *  @dev constructor of the proxy Identity contract
-     *  @param _implementationAuthority the implementation Authority contract address
-     *  @param initialManagementKey the management key at deployment
-     *  the proxy is going to use the logic deployed on the implementation contract
-     *  deployed at an address listed in the ImplementationAuthority contract
-     */
-    constructor(address _implementationAuthority, address initialManagementKey) {
-        require(_implementationAuthority != address(0), Errors.ZeroAddress());
-        require(initialManagementKey != address(0), Errors.ZeroAddress());
-
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            sstore(0x821f3e4d3d679f19eacc940c87acf846ea6eae24a63058ea750304437a62aafc, _implementationAuthority)
-        }
-
-        address logic = IImplementationAuthority(_implementationAuthority).getImplementation();
-
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool success,) = logic.delegatecall(abi.encodeWithSignature("initialize(address)", initialManagementKey));
-        require(success, Errors.InitializationFailed());
+    constructor(address _implementationAuthority, address _initialManagementKey) 
+        BeaconProxy(_implementationAuthority, abi.encodeWithSignature("initialize(address)", _initialManagementKey)) {
     }
 
-    /**
-     *  @dev fallback proxy function used for any transaction call that is made using
-     *  the Identity contract ABI and called on the proxy contract
-     *  The proxy will update its local storage depending on the behaviour requested
-     *  by the implementation contract given by the Implementation Authority
-     */
-    // solhint-disable-next-line no-complex-fallback
-    fallback() external payable {
-        address logic = IImplementationAuthority(implementationAuthority()).getImplementation();
-
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-        calldatacopy(0x0, 0x0, calldatasize())
-        let success := delegatecall(sub(gas(), 10000), logic, 0x0, calldatasize(), 0, 0)
-        let retSz := returndatasize()
-        returndatacopy(0, 0, retSz)
-        switch success
-            case 0 {
-                revert(0, retSz)
-            }
-            default {
-                return(0, retSz)
-            }
-        }
-    }
-
-    function implementationAuthority() public view returns(address) {
-        address implemAuth;
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            implemAuth := sload(0x821f3e4d3d679f19eacc940c87acf846ea6eae24a63058ea750304437a62aafc)
-        }
-        return implemAuth;
-    }
 }

--- a/contracts/proxy/ImplementationAuthority.sol
+++ b/contracts/proxy/ImplementationAuthority.sol
@@ -1,36 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
-
 pragma solidity 0.8.27;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { IImplementationAuthority } from "../interface/IImplementationAuthority.sol";
-import { Errors } from "../libraries/Errors.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 
+contract ImplementationAuthority is UpgradeableBeacon {
 
-contract ImplementationAuthority is IImplementationAuthority, Ownable {
-
-    // the address of implementation of ONCHAINID
-    address internal _implementation;
-
-    constructor(address implementation) Ownable(msg.sender) {
-        require(implementation != address(0), Errors.ZeroAddress());
-        _implementation = implementation;
-        emit UpdatedImplementation(implementation);
+    constructor(address implementation) UpgradeableBeacon(implementation, msg.sender) {
     }
 
-    /**
-     *  @dev See {IImplementationAuthority-updateImplementation}.
-     */
-    function updateImplementation(address _newImplementation) external override onlyOwner {
-        require(_newImplementation != address(0), Errors.ZeroAddress());
-        _implementation = _newImplementation;
-        emit UpdatedImplementation(_newImplementation);
-    }
-
-    /**
-     *  @dev See {IImplementationAuthority-getImplementation}.
-     */
-    function getImplementation() external override view returns(address) {
-        return _implementation;
-    }
 }

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -8,7 +8,7 @@ describe('Proxy', () => {
     const [deployerWallet, identityOwnerWallet] = await ethers.getSigners();
 
     const IdentityProxy = await ethers.getContractFactory('IdentityProxy');
-    await expect(IdentityProxy.connect(deployerWallet).deploy(ethers.ZeroAddress, identityOwnerWallet.address)).to.be.revertedWithCustomError(IdentityProxy, 'ZeroAddress');
+    await expect(IdentityProxy.connect(deployerWallet).deploy(ethers.ZeroAddress, identityOwnerWallet.address)).to.be.revertedWithCustomError(IdentityProxy, 'ERC1967InvalidBeacon');
   });
 
   it('should revert because implementation is not an identity', async () => {
@@ -19,7 +19,7 @@ describe('Proxy', () => {
     const authority = await ethers.deployContract('ImplementationAuthority', [claimIssuer.target]);
 
     const IdentityProxy = await ethers.getContractFactory('IdentityProxy');
-    await expect(IdentityProxy.connect(deployerWallet).deploy(authority.target, identityOwnerWallet.address)).to.be.revertedWithCustomError(IdentityProxy, 'InitializationFailed');
+    await expect(IdentityProxy.connect(deployerWallet).deploy(authority.target, identityOwnerWallet.address)).to.be.revertedWithCustomError(IdentityProxy, 'FailedCall');
   });
 
   it('should revert because initial key is Zero address', async () => {
@@ -29,26 +29,26 @@ describe('Proxy', () => {
     const implementationAuthority = await ethers.deployContract('ImplementationAuthority', [implementation.target]);
 
     const IdentityProxy = await ethers.getContractFactory('IdentityProxy');
-    await expect(IdentityProxy.connect(deployerWallet).deploy(implementationAuthority.target, ethers.ZeroAddress)).to.be.revertedWithCustomError(IdentityProxy, 'ZeroAddress');
+    await expect(IdentityProxy.connect(deployerWallet).deploy(implementationAuthority.target, ethers.ZeroAddress)).to.be.revertedWithCustomError(implementation, 'ZeroAddress');
   });
 
   it('should prevent creating an implementation authority with a zero address implementation', async () => {
     const [deployerWallet] = await ethers.getSigners();
 
     const ImplementationAuthority = await ethers.getContractFactory('ImplementationAuthority');
-    await expect(ImplementationAuthority.connect(deployerWallet).deploy(ethers.ZeroAddress)).to.be.revertedWithCustomError(ImplementationAuthority, 'ZeroAddress');
+    await expect(ImplementationAuthority.connect(deployerWallet).deploy(ethers.ZeroAddress)).to.be.revertedWithCustomError(ImplementationAuthority, 'BeaconInvalidImplementation');
   });
 
   it('should prevent updating to a Zero address implementation', async () => {
     const {implementationAuthority, deployerWallet} = await loadFixture(deployIdentityFixture);
 
-    await expect(implementationAuthority.connect(deployerWallet).updateImplementation(ethers.ZeroAddress)).to.be.revertedWithCustomError(implementationAuthority, 'ZeroAddress');
+    await expect(implementationAuthority.connect(deployerWallet).upgradeTo(ethers.ZeroAddress)).to.be.revertedWithCustomError(implementationAuthority, 'BeaconInvalidImplementation');
   });
 
   it('should prevent updating when not owner', async () => {
     const {implementationAuthority, aliceWallet} = await loadFixture(deployIdentityFixture);
 
-    await expect(implementationAuthority.connect(aliceWallet).updateImplementation(ethers.ZeroAddress)).to.be.revertedWithCustomError(implementationAuthority, 'OwnableUnauthorizedAccount');
+    await expect(implementationAuthority.connect(aliceWallet).upgradeTo(ethers.ZeroAddress)).to.be.revertedWithCustomError(implementationAuthority, 'OwnableUnauthorizedAccount');
   });
 
   it('should update the implementation address', async () => {
@@ -59,7 +59,7 @@ describe('Proxy', () => {
 
     const newImplementation = await ethers.deployContract('Identity', [deployerWallet.address, true]);
 
-    const tx = await implementationAuthority.connect(deployerWallet).updateImplementation(newImplementation.target);
-    await expect(tx).to.emit(implementationAuthority, 'UpdatedImplementation').withArgs(newImplementation.target);
+    const tx = await implementationAuthority.connect(deployerWallet).upgradeTo(newImplementation.target);
+    await expect(tx).to.emit(implementationAuthority, 'Upgraded').withArgs(newImplementation.target);
   });
 });


### PR DESCRIPTION
Replace beacon proxy with the OpenZeppelin ones.
Put this on a single PR as this modify the sent events, not sure if the backend uss these events.