### PR TITLE
identity: reject malleable ECDSA signatures in getRecoveredAddress

### DIFF
--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -556,8 +556,17 @@ contract Identity is Storage, IIdentity, Version {
             va := byte(0, mload(add(sig, 96)))
         }
 
-        if (va < 27) {
-            va += 27;
+        // Reject non-canonical v values instead of normalizing them: accepting
+        // v in {0, 1} lets the same signature be re-encoded with different bytes.
+        if (va != 27 && va != 28) {
+            return address(0);
+        }
+
+        // Reject malleable signatures: s must be in the lower half of the curve
+        // order (EIP-2), otherwise (r, n - s, v ^ 1) is a second valid signature
+        // for the same signer and message.
+        if (uint256(sa) > uint256(0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0)) {
+            return address(0);
         }
 
         address recoveredAddress = ecrecover(dataHash, va, ra, sa);

--- a/test/claim-issuers/revocation-malleability.test.ts
+++ b/test/claim-issuers/revocation-malleability.test.ts
@@ -1,0 +1,79 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { deployIdentityFixture } from '../fixtures';
+
+const SECP256K1_N = ethers.BigNumber.from(
+  '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141',
+);
+
+function reencodeV(signature: string): string {
+  const v = parseInt(signature.slice(-2), 16);
+  return signature.slice(0, -2) + (v - 27).toString(16).padStart(2, '0');
+}
+
+function highSFlip(signature: string): string {
+  const r = signature.slice(0, 66);
+  const s = ethers.BigNumber.from('0x' + signature.slice(66, 130));
+  const v = parseInt(signature.slice(-2), 16);
+  const sFlipped = SECP256K1_N.sub(s);
+  const vFlipped = v === 27 ? 28 : 27;
+  return r + sFlipped.toHexString().slice(2).padStart(64, '0') + vFlipped.toString(16);
+}
+
+describe('ClaimIssuer - signature malleability regression', () => {
+  // Revocation is keyed on exact signature bytes (ClaimIssuer.revokedClaims), so a
+  // malleated-but-valid variant of a revoked signature used to resurrect the claim:
+  // isClaimValid(malleated) passed and addClaim overwrote the stored signature.
+  it('rejects a revoked claim re-encoded with v in {0, 1}', async () => {
+    const { claimIssuer, claimIssuerWallet, aliceWallet, aliceIdentity, aliceClaim666 } =
+      await loadFixture(deployIdentityFixture);
+
+    await claimIssuer.connect(claimIssuerWallet).revokeClaimBySignature(aliceClaim666.signature);
+    expect(
+      await claimIssuer.isClaimValid(aliceIdentity.address, aliceClaim666.topic, aliceClaim666.signature, aliceClaim666.data),
+    ).to.be.false;
+
+    const malleated = reencodeV(aliceClaim666.signature);
+    expect(malleated).to.not.equal(aliceClaim666.signature);
+    expect(
+      await claimIssuer.isClaimValid(aliceIdentity.address, aliceClaim666.topic, malleated, aliceClaim666.data),
+    ).to.be.false;
+
+    await expect(
+      aliceIdentity
+        .connect(aliceWallet)
+        .addClaim(aliceClaim666.topic, aliceClaim666.scheme, aliceClaim666.issuer, malleated, aliceClaim666.data, aliceClaim666.uri),
+    ).to.be.revertedWith('invalid claim');
+  });
+
+  it('rejects a revoked claim re-signed via the high-s flip (r, n - s, v ^ 1)', async () => {
+    const { claimIssuer, claimIssuerWallet, aliceWallet, aliceIdentity, aliceClaim666 } =
+      await loadFixture(deployIdentityFixture);
+
+    await claimIssuer.connect(claimIssuerWallet).revokeClaimBySignature(aliceClaim666.signature);
+    expect(
+      await claimIssuer.isClaimValid(aliceIdentity.address, aliceClaim666.topic, aliceClaim666.signature, aliceClaim666.data),
+    ).to.be.false;
+
+    const malleated = highSFlip(aliceClaim666.signature);
+    expect(malleated).to.not.equal(aliceClaim666.signature);
+    expect(
+      await claimIssuer.isClaimValid(aliceIdentity.address, aliceClaim666.topic, malleated, aliceClaim666.data),
+    ).to.be.false;
+
+    await expect(
+      aliceIdentity
+        .connect(aliceWallet)
+        .addClaim(aliceClaim666.topic, aliceClaim666.scheme, aliceClaim666.issuer, malleated, aliceClaim666.data, aliceClaim666.uri),
+    ).to.be.revertedWith('invalid claim');
+  });
+
+  it('still accepts the canonical signature', async () => {
+    const { claimIssuer, aliceIdentity, aliceClaim666 } = await loadFixture(deployIdentityFixture);
+
+    expect(
+      await claimIssuer.isClaimValid(aliceIdentity.address, aliceClaim666.topic, aliceClaim666.signature, aliceClaim666.data),
+    ).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary

`Identity.getRecoveredAddress` accepted malleable ECDSA signatures: it normalized `v` with `if (v < 27) v += 27` and never enforced the EIP-2 low-s rule. The same signer/message pair therefore admits multiple distinct signature byte strings:

- **v re-encoding**: `(r, s, 27)` and `(r, s, 0)` recover the same address
- **high-s flip**: `(r, n - s, v ^ 1)` recovers the same address

This breaks claim revocation. `ClaimIssuer.revokedClaims` is keyed on exact signature bytes, `isClaimValid` checks revocation against the *presented* signature, and `Identity.addClaim` overwrites the stored signature of an existing `claimId` whenever the new signature validates. A holder whose claim was revoked can re-add a malleated variant of the revoked signature: `isClaimValid` passes (same recovered purpose-3 signer, `revokedClaims[variant]` is false) and the stored signature is replaced, so the revoked claim validates again.

## Fix

Pin `v` to `{27, 28}` (no normalization) and reject `s` above the half curve order, returning `address(0)` in line with the existing invalid-length path. This matches the canonicality rules in OpenZeppelin's ECDSA library.

## Tests

New `test/claim-issuers/revocation-malleability.test.ts`:

- `rejects a revoked claim re-encoded with v in {0, 1}`: fails without the fix (bypass succeeds), passes with it
- `rejects a revoked claim re-signed via the high-s flip (r, n - s, v ^ 1)`: fails without the fix, passes with it
- `still accepts the canonical signature`: passes before and after

Full suite: 157 passing.

Note: signers that emit `v` as `0`/`1` must re-encode to `27`/`28` (ethers, web3 and hardware wallets already do).

Tooling: PR prepared with Cursor agent assistance.

Made with [Cursor](https://cursor.com)